### PR TITLE
Add loader and `query` subcommand

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -1,4 +1,4 @@
-# Terminology
+# Glossary
 
 Many concepts are universal across formats and languages, but are known by
 various names nonetheless. RCL adopts the following terminology.

--- a/docs/rcl_evaluate.md
+++ b/docs/rcl_evaluate.md
@@ -1,0 +1,20 @@
+# rcl evaluate
+
+## Synopsis
+
+    rcl evaluate <input>
+
+Shorthands:
+
+    rcl eval
+    rcl e
+
+## Description
+
+Read an RCL expression from the file `<input>`, and evaluate it. When `<input>`
+is `-`, read from stdin instead. Print the evaluated result as json to stdout.
+
+## Options
+
+TODO: This should take an `--output` option to switch between pretty json and
+compact json. And possibly we should output yaml, HCL, ...

--- a/docs/rcl_format.md
+++ b/docs/rcl_format.md
@@ -1,0 +1,21 @@
+# rcl format
+
+## Synopsis
+
+    rcl format <input>
+
+Shorthands:
+
+    rcl fmt
+    rcl f
+
+## Description
+
+Read an RCL expression from the file `<input>`, and format it according to the
+standard style. When `<input>` is `-`, read from stdin instead. Print the result
+to stdout.
+
+## Options
+
+ * TODO: There should be an `--in-place` option to write the result.
+ * TODO: There should be a `--check` option to indicate if formatting is correct.

--- a/docs/rcl_highlight.md
+++ b/docs/rcl_highlight.md
@@ -1,0 +1,16 @@
+# rcl highlight
+
+## Synopsis
+
+    rcl highlight <input>
+
+## Description
+
+Read an RCL expression from the file `<input>`, and print a syntax-highlighted
+result to stout. When `<input>` is `-`, read from stdin instead.
+
+## Options
+
+TODO: There should be an option to write html instead of ansi escape codes, or
+some other format that could easily be consumed, for example to integrate with
+Pygments. Or maybe only some directives to compare against an external lexer.

--- a/docs/rcl_query.md
+++ b/docs/rcl_query.md
@@ -1,0 +1,25 @@
+# rcl query
+
+## Synopsis
+
+    rcl query <input> <expr>
+
+Shorthands:
+
+    rcl q
+
+## Description
+
+Evaluate an expression against an input.
+
+ * Read an RCL expression from the file `<input>`. When `<input>` is `-`,
+   read from stdin instead.
+ * Evaluate the expression `<expr>`, in a context where the variable `input`
+   is bound to the result of the input document.
+
+This can be used to peek into a sub-element of a document that evaluates to a
+large expression, but it can also be used for ad-hoc data querying, as an
+alternative to jq. For example:
+
+    echo '[12, 42, 33]' | rcl q - '[for x in input: f"Double {x} is {x * 2}."]'
+    ["Double 12 is 24.","Double 42 is 84.","Double 33 is 66."]

--- a/docs/syntax_highlighting.md
+++ b/docs/syntax_highlighting.md
@@ -7,3 +7,8 @@ The repository ships with basic syntax definitions for the editors below.
 The directory `etc/rcl.vim` contains support for highlighting in Vim. You can
 symlink the contents into your `~/.vim`, or use a plugin manager like Pathogen
 and symlink the directory into `~/.vim/bundle`.
+
+## rcl highlight
+
+Aside from editor support, [`rcl highlight`](rcl_highlight.md) will highlight an
+expression using its internal parser.

--- a/golden/error/json_function.test
+++ b/golden/error/json_function.test
@@ -2,8 +2,8 @@
 "frobnicator".len
 
 # output:
- --> stdin:2:0
+ --> stdin:1:0
   |
-2 | "frobnicator".len
-  | ^~~~~~~~~~~~~~~~~
+1 | // Note, .len is an unserializable function, we don't call it!
+  | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Error: Functions cannot be exported as json.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -16,9 +16,14 @@ markdown_extensions:
 nav:
   - "Overview": "index.md"
   - "User guide":
-    - "Syntax highlighting": "syntax_highlighting.md"
-    - "Terminology": "terminology.md"
-    - "Syntax": "syntax.md"
-    - "Strings": "strings.md"
-    - "Null": "null.md"
+      - "Syntax highlighting": "syntax_highlighting.md"
+      - "Syntax": "syntax.md"
+      - "Strings": "strings.md"
+      - "Null": "null.md"
+      - "Glossary": "glossary.md"
+  - "Reference":
+      - "rcl evaluate": "rcl_evaluate.md"
+      - "rcl format": "rcl_format.md"
+      - "rcl highlight": "rcl_highlight.md"
+      - "rcl query": "rcl_query.md"
   - "Development": "development.md"

--- a/src/error.rs
+++ b/src/error.rs
@@ -143,7 +143,7 @@ fn highlight_span_in_line(inputs: &Inputs, span: Span, highlight_ansi: &str) -> 
     writeln!(
         &mut result,
         "{}--> {}:{}:{}",
-        line_num_pad, doc.path, line, column,
+        line_num_pad, doc.name, line, column,
     )
     .unwrap();
     writeln!(&mut result, "{} |", line_num_pad).unwrap();
@@ -165,6 +165,56 @@ fn highlight_span_in_line(inputs: &Inputs, span: Span, highlight_ansi: &str) -> 
     .unwrap();
 
     result
+}
+
+/// We encountered some IO failure.
+#[derive(Debug)]
+pub struct IoError {
+    // TODO: Make optional.
+    pub span: Span,
+    pub message: String,
+}
+
+impl IoError {
+    pub fn new(message: String) -> IoError {
+        IoError {
+            span: Span::new(crate::source::DocId(0), 0, 0),
+            message,
+        }
+    }
+}
+
+impl From<String> for IoError {
+    fn from(err: String) -> Self {
+        IoError::new(err)
+    }
+}
+
+impl From<&str> for IoError {
+    fn from(err: &str) -> Self {
+        IoError::new(err.to_string())
+    }
+}
+
+impl From<IoError> for Box<dyn Error> {
+    fn from(err: IoError) -> Self {
+        Box::new(err)
+    }
+}
+
+impl Error for IoError {
+    fn span(&self) -> Span {
+        self.span
+    }
+    fn message(&self) -> &str {
+        &self.message
+    }
+    fn notes(&self) -> &[(Span, &str)] {
+        &[]
+    }
+    fn help(&self) -> Option<&str> {
+        None
+    }
 }
 
 /// A syntax error that causes lexing or parsing to fail.

--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -250,12 +250,12 @@ impl<'a> Formatter<'a> {
                 begin,
                 holes,
                 style: QuoteStyle::Double,
-            } => self.format_string_double(*begin, &holes),
+            } => self.format_string_double(*begin, holes),
             Expr::FormatString {
                 begin,
                 holes,
                 style: QuoteStyle::Triple,
-            } => self.format_string_triple(*begin, &holes),
+            } => self.format_string_triple(*begin, holes),
 
             Expr::NumHexadecimal(span) => {
                 // Normalize A-F to a-f.

--- a/src/json.rs
+++ b/src/json.rs
@@ -14,6 +14,8 @@ use crate::string::escape_json;
 
 /// Render a value as json.
 pub fn format_json(caller: Span, v: &Value, into: &mut String) -> Result<()> {
+    // TODO: Instead of the caller span, we should have a dedicated error type
+    // for reporting runtime errors.
     match v {
         Value::Null => into.push_str("null"),
         Value::Bool(true) => into.push_str("true"),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,7 @@ pub mod fmt;
 pub mod highlight;
 pub mod json;
 pub mod lexer;
+pub mod loader;
 pub mod parser;
 pub mod pprint;
 pub mod runtime;

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -1,0 +1,152 @@
+// RCL -- A sane configuration language.
+// Copyright 2023 Ruud van Asseldonk
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// A copy of the License has been included in the root of the repository.
+
+//! The loader is responsible for loading documents.
+
+use std::fs;
+use std::io::{self, Read};
+use std::path::Path;
+use std::rc::Rc;
+
+use crate::abstraction;
+use crate::ast;
+use crate::cst;
+use crate::error::{IoError, Result};
+use crate::eval;
+use crate::lexer;
+use crate::parser;
+use crate::runtime::{Env, Value};
+use crate::source::{Doc, DocId, Span};
+
+/// An owned document.
+///
+/// `Document` is to [`Doc`] what `String` is to `&str`.
+struct Document {
+    /// A friendly name for the source, usually the file path.
+    name: String,
+    /// The document contents.
+    data: String,
+}
+
+impl Document {
+    pub fn as_doc(&self) -> Doc {
+        Doc {
+            name: &self.name,
+            data: &self.data,
+        }
+    }
+}
+
+#[derive(Default)]
+pub struct Loader {
+    documents: Vec<Document>,
+}
+
+impl Loader {
+    pub fn new() -> Loader {
+        Loader::default()
+    }
+
+    /// Borrow all documents.
+    pub fn as_inputs(&self) -> Vec<Doc> {
+        self.documents.iter().map(Document::as_doc).collect()
+    }
+
+    /// Borrow a document.
+    pub fn get_doc(&self, id: DocId) -> Doc {
+        self.documents[id.0 as usize].as_doc()
+    }
+
+    /// Return the span that covers the entire document.
+    pub fn get_span(&self, id: DocId) -> Span {
+        Span::new(id, 0, self.documents[id.0 as usize].data.len())
+    }
+
+    /// Lex the given document and return its tokens.
+    pub fn get_tokens(&self, id: DocId) -> Result<Vec<lexer::Lexeme>> {
+        let doc = self.get_doc(id);
+        let tokens = lexer::lex(id, doc.data)?;
+        Ok(tokens)
+    }
+
+    /// Parse the given document and return its Concrete Syntax Tree.
+    pub fn get_cst(&self, id: DocId) -> Result<cst::Prefixed<cst::Expr>> {
+        let doc = self.get_doc(id);
+        let tokens = self.get_tokens(id)?;
+        let (_doc_span, expr) = parser::parse(id, doc.data, &tokens)?;
+        Ok(expr)
+    }
+
+    /// Parse the given document and return its Abstract Syntax Tree.
+    pub fn get_ast(&self, id: DocId) -> Result<ast::Expr> {
+        let doc = self.get_doc(id);
+        let cst = self.get_cst(id)?;
+        let ast = abstraction::abstract_expr(doc.data, &cst)?;
+        Ok(ast)
+    }
+
+    /// Evaluate the given document and return the resulting value.
+    pub fn evaluate(&self, id: DocId, env: &mut Env) -> Result<Rc<Value>> {
+        let expr = self.get_ast(id)?;
+        let result = eval::eval(env, &expr)?;
+        Ok(result)
+    }
+
+    fn push(&mut self, document: Document) -> DocId {
+        let n = self.documents.len();
+        self.documents.push(document);
+        DocId(n.try_into().expect("Cannot load that many documents!"))
+    }
+
+    /// Load stdin into a new document.
+    pub fn load_stdin(&mut self) -> Result<DocId> {
+        let mut buf = String::new();
+        io::stdin()
+            .read_to_string(&mut buf)
+            .map_err(|err| IoError::from(format!("Failed to read from stdin: {}.", err.kind())))?;
+        let doc = Document {
+            name: "stdin".to_string(),
+            data: buf,
+        };
+        Ok(self.push(doc))
+    }
+
+    /// Load a file into a new document.
+    pub fn load_file<P: AsRef<Path>>(&mut self, path: P) -> Result<DocId> {
+        // TODO: Deduplicate, don't load the same document twice.
+        let buf = fs::read_to_string(&path).map_err(|err| {
+            IoError::from(format!(
+                "Failed to read from file '{}': {}.",
+                path.as_ref().to_string_lossy(),
+                err.kind(),
+            ))
+        })?;
+        let doc = Document {
+            // TODO: Canonicalize all paths to be relative to the working directory.
+            name: path.as_ref().to_string_lossy().into_owned(),
+            data: buf,
+        };
+        Ok(self.push(doc))
+    }
+
+    /// Load a string into a new document.
+    pub fn load_string(&mut self, data: String) -> DocId {
+        let doc = Document {
+            name: "input".to_string(),
+            data,
+        };
+        self.push(doc)
+    }
+
+    /// Load the file with the given name, or stdin if the name is `-`.
+    pub fn load_from_cli_fname(&mut self, fname: &str) -> Result<DocId> {
+        match fname {
+            "-" => self.load_stdin(),
+            _ => self.load_file(fname),
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,19 +14,21 @@ const USAGE: &str = r#"
 RCL -- Ruud's Configuration Language.
 
 Usage:
-  rcl eval <file>
-  rcl fmt <file>
+  rcl evaluate <file>
+  rcl format <file>
   rcl highlight <file>
-  rcl repl
   rcl query <file> <expr>
+  rcl repl
   rcl -h | --help
 
 Arguments:
-  <file>        The input file to process, or '-' for stdin.
-  <expr>        An RCL expression to evaluate against the input document.
+  <file>      The input file to process, or '-' for stdin.
+  <expr>      An RCL expression to evaluate against the input document.
 
 Options:
-  -h --help     Show this screen.
+  -h --help   Show this screen.
+
+See the manual for a more elaborate usage guide.
 "#;
 
 fn main_eval(loader: &Loader, doc: DocId) -> Result<()> {
@@ -96,11 +98,11 @@ fn main_with_loader(loader: &mut Loader) -> Result<()> {
             println!("{}", USAGE.trim());
             std::process::exit(0)
         }
-        ["eval", fname] => {
+        ["e", fname] | ["eval", fname] | ["evaluate", fname] => {
             let doc = loader.load_from_cli_fname(fname)?;
             main_eval(loader, doc)
         }
-        ["fmt", fname] => {
+        ["f", fname] | ["fmt", fname] | ["format", fname] => {
             let doc = loader.load_from_cli_fname(fname)?;
             main_fmt(loader, doc)
         }
@@ -111,7 +113,7 @@ fn main_with_loader(loader: &mut Loader) -> Result<()> {
         ["repl"] => {
             unimplemented!("TODO: Implement repl.");
         }
-        ["query", fname, expr] => {
+        ["q", fname, expr] | ["query", fname, expr] => {
             let input = loader.load_from_cli_fname(fname)?;
             let query = loader.load_string(expr.to_string());
             main_query(loader, input, query)

--- a/src/main.rs
+++ b/src/main.rs
@@ -78,7 +78,7 @@ fn main_highlight(loader: &Loader, doc: DocId) -> Result<()> {
     let tokens = loader.get_tokens(doc)?;
     let data = loader.get_doc(doc).data;
     let mut stdout = std::io::stdout().lock();
-    let res = rcl::highlight::highlight(&mut stdout, &tokens, &data);
+    let res = rcl::highlight::highlight(&mut stdout, &tokens, data);
     if res.is_err() {
         // If we fail to print to stdout, there is no point in printing
         // an error, just exit then.

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -7,14 +7,13 @@
 
 use crate::cst::{BinOp, Expr, FormatHole, NonCode, Prefixed, Seq, UnOp};
 use crate::error::{IntoParseError, ParseError};
-use crate::lexer::{self, QuoteStyle, Token};
+use crate::lexer::{Lexeme, QuoteStyle, Token};
 use crate::source::{DocId, Span};
 
 pub type Result<T> = std::result::Result<T, ParseError>;
 
 /// Parse an input document into a concrete syntax tree.
-pub fn parse(doc: DocId, input: &str) -> Result<(Span, Prefixed<Expr>)> {
-    let tokens = lexer::lex(doc, input)?;
+pub fn parse(doc: DocId, input: &str, tokens: &[Lexeme]) -> Result<(Span, Prefixed<Expr>)> {
     let mut parser = Parser::new(doc, input, &tokens);
 
     // Comments at the start of the document are allowed, but the document

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -14,7 +14,7 @@ pub type Result<T> = std::result::Result<T, ParseError>;
 
 /// Parse an input document into a concrete syntax tree.
 pub fn parse(doc: DocId, input: &str, tokens: &[Lexeme]) -> Result<(Span, Prefixed<Expr>)> {
-    let mut parser = Parser::new(doc, input, &tokens);
+    let mut parser = Parser::new(doc, input, tokens);
 
     // Comments at the start of the document are allowed, but the document
     // should not start with blank lines, those we drop.

--- a/src/source.rs
+++ b/src/source.rs
@@ -10,16 +10,16 @@
 use std::fmt;
 
 /// A named input document.
-pub struct Document<'a> {
+pub struct Doc<'a> {
     /// Path can be a file path, but also a name such as "stdin".
-    pub path: &'a str,
+    pub name: &'a str,
 
     /// The contents of the file.
     pub data: &'a str,
 }
 
 /// A list of input documents.
-pub type Inputs<'a> = [Document<'a>];
+pub type Inputs<'a> = [Doc<'a>];
 
 /// The index of a document in the list of input files.
 #[derive(Copy, Clone, Eq, Ord, PartialEq, PartialOrd)]


### PR DESCRIPTION
* Put everything related to loading documents into the `loader` module.
* Add a new subcommand, `query`, that loads the input from a file, and an expression from the command line, and then evaluates the expression with the input bound to `input`. This can be used to query json (or RCL) documents, as a `jq` alternative.

Things left to do:

- [x] Spans should be optional for errors; for IO errors we can’t give one.
- [x] Json export should not take a span to report the error, rather some kind of json path through the object. Though having the full span of the expression is useful, so we can report errors at least at the right place, not inside a comment. This PR breaks this.