### PR TITLE
Add Pygments lexer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,8 @@
 # Nix
 /result*
 
+# Python venv managed by Nix
+/.venv
+
+# MkDocs
+/site

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,3 +1,0 @@
-# Development
-
-TODO:

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,25 +24,26 @@ hypothetical._
 
 ## Example
 
-    // TODO: Add a better example.
-    let sevices_at = {
-      server01 = ["ssh", "http"];
-      server02 = ["ssh", "imap"];
-      server03 = ["ssh", "pop3"];
-    };
-    let ports_for = {
-      ssh = [22];
-      http = [80, 443];
-      imap = [993];
-      pop3 = [995];
-    };
-    let firewall_rules = {
-      for server, services in services_at:
-      server: [
-        for service in services:
-        for port in ports_for[service]:
-        { rule = "allow"; port = port; }
-      ]
-    };
-    firewall_rules
-
+```rcl
+ // TODO: Add a better example.
+ let sevices_at = {
+   server01 = ["ssh", "http"];
+   server02 = ["ssh", "imap"];
+   server03 = ["ssh", "pop3"];
+ };
+ let ports_for = {
+   ssh = [22];
+   http = [80, 443];
+   imap = [993];
+   pop3 = [995];
+ };
+ let firewall_rules = {
+   for server, services in services_at:
+   server: [
+     for service in services:
+     for port in ports_for[service]:
+     { rule = "allow"; port = port; }
+   ]
+ };
+ firewall_rules
+```

--- a/docs/strings.md
+++ b/docs/strings.md
@@ -6,17 +6,23 @@ inspiration from Nix and Rust. All json strings are valid in RCL[^1].
 
 Strings can be quoted with double quotes:
 
-    "Hello, world"
+```rcl
+"Hello, world"
+```
 
 Or with triple double quotes:
 
-    """
-    Hello, world
-    """
+```rcl
+"""
+Hello, world
+"""
+```
 
 In both cases, add an `f` to enable interpolation.
 
-    f"Hello {greetee}"
+```rcl
+f"Hello {greetee}"
+```
 
 [^1]: Except for `\u` escape sequences that encode surrogate code points
 (U+D800 through U+DFFF). While a pair of such escape sequences may together be
@@ -30,18 +36,20 @@ string, any shared leading whitespace gets removed, as well as the mandatory
 newline that directly follows the `"""`. If there is a trailing newline, then
 that one _is_ part of the string. The following strings are identical:
 
-    let a = "Hello\n  World\n";
-    let b = "Hello
-      World\n";
-    let c =
-      """
-      Hello
-        World
-      """;
-    let d =
-      """
-        Hello
-          World\n""";
+```rcl
+let a = "Hello\n  World\n";
+let b = "Hello
+  World\n";
+let c =
+  """
+  Hello
+    World
+  """;
+let d =
+  """
+    Hello
+      World\n""";
+```
 
 Inside a `"`-quoted string, `"` itself needs to be escaped as `\"`, but inside
 a `"""`-quoted string, `"` does not need to be escaped. Inside a `"""`-quoted
@@ -52,14 +60,16 @@ Blank lines inside the string do not defeat shared leading whitespace. This
 means that the following expression returns true without any of the lines in
 the document containing trailing whitespace:
 
-    let x =
-       """
-       Section 1
+```rcl
+let x =
+   """
+   Section 1
 
-       Section 2
-       """;
-    let y = "Section 1\n\nSection 2\n";
-    x == y
+   Section 2
+   """;
+let y = "Section 1\n\nSection 2\n";
+x == y
+```
 
 ## Interpolation
 
@@ -72,15 +82,17 @@ is no nesting limitation. (Like in Nix, but unlike Python.)
 
 An example of string interpolation:
 
-    let generations = {
-      "Leon Kowalski": 6,
-      "Rachael": 7,
-      "Roy Batty": 6,
-    };
-    [
-      for name, generation in generations:
-      f"{name} was a Nexus-{generation} replicant."
-    ]
+```rcl
+let generations = {
+  "Leon Kowalski": 6,
+  "Rachael": 7,
+  "Roy Batty": 6,
+};
+[
+  for name, generation in generations:
+  f"{name} was a Nexus-{generation} replicant."
+]
+```
 
 ## Escape sequences
 
@@ -92,7 +104,9 @@ can be followed by either exactly 4 hex digits (like in json and Python), or by
 a variable number of hex digits enclosed in `[]` (like in Rust, except enclosed
 in `[]` instead of `{}`). The following strings are identical:
 
-    let a = "\n";
-    let b = "\u000a";
-    let c = "\u[0a]";
-    let d = "\u[00000a]";
+```rcl
+let a = "\n";
+let b = "\u000a";
+let c = "\u[0a]";
+let d = "\u[00000a]";
+```

--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -10,16 +10,20 @@ slightly unusual in that there are some locations where comments are not
 allowed.[^1] Generally, prefer to put comments on their own line, before the
 item they comment on.
 
-    // Comment like this.
-    let answer = 42;
-    let question = "unknown"; // The formatter would move this to the next line.
-    { question: answer }
+```rcl
+// Comment like this.
+let answer = 42;
+let question = "unknown"; // The formatter would move this to the next line.
+{ question: answer }
+```
 
 At the start of the document, a line that starts with `#!` is allowed, in order
 to support executable files. For example:
 
-    #!/usr/bin/env -S rcl eval
-    "This document prints this string when executed."
+```rcl
+#!/usr/bin/env -S rcl eval
+"This document prints this string when executed."
+```
 
 [^1]: The reason for disallowing comments in arbitrary locations, is that RCL
 has a single syntax tree that is used both by the formatter and the evaluator.
@@ -37,15 +41,19 @@ The booleans are written `true` and `false`, null is written `null`.
 
 Strings are quoted with `"` and support the same escape sequences as json.
 
-    "This is a string."
+```rcl
+"This is a string."
+```
 
 Multi-line strings can be quoted with `"""`. In both cases, adding an `f` in
 front turns the string into a format string, which can have one or more _holes_
 delimited by `{}`, to interpolate content into it:
 
-    f"""
-    The answer to the ultimate question is {2 * 3 * 7}.
-    """
+```rcl
+f"""
+The answer to the ultimate question is {2 * 3 * 7}.
+"""
+```
 
 See [the chapter on strings](strings.md) for the full details.
 
@@ -54,10 +62,12 @@ See [the chapter on strings](strings.md) for the full details.
 Lists are surrounded by `[]`. The list separator is `,` and a trailing comma is
 allowed but not required.
 
-    [
-      ["Apple", "Banana", "Pear"],
-      ["Eggplant", "Pepper", "Zuccini"],
-    ]
+```rcl
+[
+  ["Apple", "Banana", "Pear"],
+  ["Eggplant", "Pepper", "Zuccini"],
+]
+```
 
 ## Dictionaries
 
@@ -66,29 +76,35 @@ in json form, where the left-hand side is an expression. Then the key and value
 are separated by `:` and the element separator is `,`. A trailing comma is
 optional.
 
-    {
-      "name": "apple",
-      "flavor": "sweet",
-    }
+```rcl
+{
+  "name": "apple",
+  "flavor": "sweet",
+}
+```
 
 The left-hand side does not have to be a string, although using other types than
 strings precludes serialization to json.
 
-    {
-      1: "I",
-      5: "V",
-      5 + 5: "X",
-    }
+```rcl
+{
+  1: "I",
+  5: "V",
+  5 + 5: "X",
+}
+```
 
 Alternatively, dicts can be written in record form, where the left-hand side
 is an identifier. Then the key and value are separated by `=` and the element
 separator is `;`. A trailing semicolon is optional. The following value is
 identical to the first one above.
 
-    {
-      name = "apple";
-      flavor = "sweet";
-    }
+```rcl
+{
+  name = "apple";
+  flavor = "sweet";
+}
+```
 
 Note, the empty collection `{}` is a dict, not a set.
 
@@ -97,25 +113,31 @@ Note, the empty collection `{}` is a dict, not a set.
 Sets are surrounded by `{}` and work otherwise the same as lists. The following
 list contains two identical sets:
 
-    [
-      {"Apple", "Pear"},
-      {"Apple", "Pear", "Apple"},
-    ]
+```rcl
+[
+  {"Apple", "Pear"},
+  {"Apple", "Pear", "Apple"},
+]
+```
 
 Note, the empty collection `{}` is a dict, not a set. There is currently no
 literal for the empty set. It is possible to work around this using
 comprehensions:
 
-    // An empty set.
-    {for x in []: x}
+```rcl
+// An empty set.
+{for x in []: x}
+```
 
 ## Let bindings
 
 Values can be bound to names with a let-binding.
 
-    let name = "apple";
-    let flavor = "sweet";
-    [name, flavor]
+```rcl
+let name = "apple";
+let flavor = "sweet";
+[name, flavor]
+```
 
 A let-binding is an _expression_, not an assignment statement. The expression
 evaluates to the expression after `;`.
@@ -135,15 +157,17 @@ Unlike most other languages (but [like Pony][pony-ops]), RCL does not have
 different precedence levels. To avoid confusing combinations of operators, you
 have to use parentheses:
 
-    // Invalid: Unclear whether this means (X and Y) or Z, or X and (Y or Z).
-    let should_log_verbose =
-      settings.contains("log") and settings.log_level >= 2
-      or settings.contains("debug");
+```rcl
+// Invalid: Unclear whether this means (X and Y) or Z, or X and (Y or Z).
+let should_log_verbose =
+  settings.contains("log") and settings.log_level >= 2
+  or settings.contains("debug");
 
-    // Disambiguate with parens:
-    let should_log_verbose =
-      (settings.contains("log") and (settings.log_level >= 2))
-      or settings.contains("debug");
+// Disambiguate with parens:
+let should_log_verbose =
+  (settings.contains("log") and (settings.log_level >= 2))
+  or settings.contains("debug");
+```
 
 [pony-ops]: https://tutorial.ponylang.io/expressions/ops.html#precedence
 
@@ -153,40 +177,46 @@ Inside collection literals (lists, dicts, and sets), aside from single
 elements, it is possible to use comprehensions. There are three supported
 constructs: `for`, `if`, and `let`.
 
-    let dict = {"name": "pear", "flavor": "sweet"};
-    [for key, value in dict: value]
-    // Evaluates to:
-    ["pear", "sweet"]
+```rcl
+let dict = {"name": "pear", "flavor": "sweet"};
+[for key, value in dict: value]
+// Evaluates to:
+["pear", "sweet"]
 
-    [if log_level >= 2: "Verbose message"]
-    // When log_level < 2, evaluates to:
-    []
-    // When log_level >= 2, evaluates to:
-    ["Verbose message"]
+[if log_level >= 2: "Verbose message"]
+// When log_level < 2, evaluates to:
+[]
+// When log_level >= 2, evaluates to:
+["Verbose message"]
 
-    {let x = 10; "value": x}
-    // Evaluates to:
-    {"value": 10}
+{let x = 10; "value": x}
+// Evaluates to:
+{"value": 10}
+```
 
 These can be combined arbitrarily:
 
-    let labels = {
-      for server in servers:
-      let all_server_labels = server_labels[server] | default_labels;
-      for label in all_server_labels:
-      if not excluded_labels.contains(label):
-      label
-    };
+```rcl
+let labels = {
+  for server in servers:
+  let all_server_labels = server_labels[server] | default_labels;
+  for label in all_server_labels:
+  if not excluded_labels.contains(label):
+  label
+};
+```
 
 There can be multiple loops per collection, and they can be mixed with single
 elements:
 
-    let small_numbers = [1, 2, 3];
-    let large_numbers = [100, 200, 300];
-    [
-      for n in small_numbers: n,
-      10,
-      for n in large_numbers: n,
-    ]
-    // Evaluates to:
-    [1, 2, 3, 10, 100, 200, 300]
+```rcl
+let small_numbers = [1, 2, 3];
+let large_numbers = [100, 200, 300];
+[
+  for n in small_numbers: n,
+  10,
+  for n in large_numbers: n,
+]
+// Evaluates to:
+[1, 2, 3, 10, 100, 200, 300]
+```

--- a/docs/syntax_highlighting.md
+++ b/docs/syntax_highlighting.md
@@ -1,6 +1,12 @@
 # Syntax highlighting
 
-The repository ships with basic syntax definitions for the editors below.
+The repository ships with basic syntax definitions for the applications below.
+
+## Pygments
+
+The directory `etc/pygments` contains a file `rcl.py` that you can drop into a
+Pygments fork in the `pygments/lexers` directory. This lexer powers the syntax
+highlighting in this manual.
 
 ## Vim
 
@@ -8,7 +14,7 @@ The directory `etc/rcl.vim` contains support for highlighting in Vim. You can
 symlink the contents into your `~/.vim`, or use a plugin manager like Pathogen
 and symlink the directory into `~/.vim/bundle`.
 
-## rcl highlight
+## External
 
 Aside from editor support, [`rcl highlight`](rcl_highlight.md) will highlight an
 expression using its internal parser.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,58 @@
+# Testing
+
+RCL is tested extensively. The two primary means of testing are golden tests
+and fuzzing.
+
+## Golden tests
+
+Golden tests are located in the `golden` directory as files ending in `.test`.
+Every file consists of two sections: an input, then a line
+
+    # output:
+
+and then an expected output. The test runner `golden/run.py` takes these files,
+executes <abbr>RCL</abbr>, and compares the actual output against the expected
+output. The mode in which `run.py` executes <abbr>RCL</abbr> depends on the
+subdirectory that the tests are in. See the docstring in `run.py` for more
+information.
+
+The goal of the golden tests is to cover all relevant branches of the code. For
+example, every error message that <abbr>RCL</abbr> can generate should be
+accompanied by a test that triggers it. It is instructive to inspect the
+coverage report to see what tests are missing, or to discover pieces of dead
+code. The easiest way to generate the report is with Nix:
+
+    nix build .#coverage --out-link result
+    xdg-open result/index.html
+
+Alternatively, you can build with coverage support and run `grcov` manually,
+see `flake.nix` for the exact flags and commands.
+
+## Fuzz tests
+
+The other means of testing are fuzz tests. RCL contains one primary fuzzer
+called `main`, whose fuzz inputs are valid <abbr>RCL</abbr> files that contain a
+little bit of metadata about what to exercise. Putting everything in one fuzzer
+enables sharing the corpus across the different modes.
+
+The basic modes of the fuzzer just test that the lexer, parser, and evaluator
+do not crash. They are useful for finding mistakes such as slicing a string
+across a code point binary, or trying to consume tokens past the end of the
+document. However the more interesting fuzzers are the formatter, and the value
+pretty-printer. They verify the following properties:
+
+ * The formatter is idempotent. Running `rcl fmt` on an already-formatted file
+   should not change it. This sounds obvious, but the fuzzer caught a few
+   interesting cases related to trailing whitespace and multiline strings.
+ * The evaluator is idempotent. RCL can evaluate to json, and is itself a
+   superset of json, so evaluating the same input again should not change it.
+
+## Unit tests
+
+There is less of a focus on unit tests. Constructing all the right environment
+and values for even a very basic test quickly becomes unwieldy; even the
+<abbr>AST</abbr> of a few lines of code, when constructed directly in Rust,
+becomes hundreds of lines of code. Rather than constructing the <abbr>AST</abbr>
+by hand, we can just use the parser to construct one. Similarly, for expected
+output values, instead of constructing these in Rust, we can format them, and
+express the entire process as a golden test instead.

--- a/etc/pygments/rcl.py
+++ b/etc/pygments/rcl.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+
+# RCL -- A sane configuration language.
+# Copyright 2023 Ruud van Asseldonk
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# A copy of the License has been included in the root of the repository.
+
+from pygments.lexer import RegexLexer
+from pygments.token import Text
+
+
+class RclLexer(RegexLexer):
+    name = "RCL"
+    aliases = ["rcl"]
+    filenames = ["*.rcl"]

--- a/etc/pygments/rcl.py
+++ b/etc/pygments/rcl.py
@@ -7,6 +7,10 @@
 # you may not use this file except in compliance with the License.
 # A copy of the License has been included in the root of the repository.
 
+# To test this lexer:
+# python -m pygments -x -l etc/pygments/rcl.py:RclLexer examples/tags.rcl
+# See also <https://pygments.org/docs/lexerdevelopment/>.
+
 from pygments.lexer import RegexLexer, words
 from pygments import token
 
@@ -26,9 +30,9 @@ class RclLexer(RegexLexer):
             (r"#!.*?$", token.Comment.Hashbang),
             (r"//.*?$", token.Comment),
             (r'f"""', token.String, "format_triple_open"),
-            (r'"""', token.String, "triple_open"),
+            (r'"""', token.String, "string_triple"),
             (r'f"', token.String, "format_double_open"),
-            (r'"', token.String, "double_open"),
+            (r'"', token.String, "string_double"),
             # TODO: Handle the }
             (r"0b[01_]+", token.Number.Bin),
             (r"0x[0-9a-fA-F_]+", token.Number.Hex),
@@ -79,6 +83,22 @@ class RclLexer(RegexLexer):
         ],
         "format_double_open": [],
         "format_triple_open": [],
-        "double_open": [],
-        "triple_open": [],
+        "string_double": [
+            (r'[^\\"]+', token.String),
+            (r"\\", token.String.Escape, "escape"),
+            (r'"', token.String, "#pop"),
+        ],
+        "string_triple": [
+            (r'[^\\"]+', token.String),
+            # Only """ ends the string, but " cannot occur in the above state,
+            # so list those two explicitly.
+            (r'""|"', token.String),
+            (r"\\", token.String.Escape, "escape"),
+            (r'"""', token.String, "#pop"),
+        ],
+        "escape": [
+            (r'["\\/bfnrt{]', token.String.Escape, "#pop"),
+            (r"u\[[0-9a-fA-F]+\]", token.String.Escape, "#pop"),
+            (r"u[0-9a-fA-F]{4}", token.String.Escape, "#pop"),
+        ],
     }

--- a/etc/pygments/rcl.py
+++ b/etc/pygments/rcl.py
@@ -14,6 +14,66 @@
 from pygments.lexer import RegexLexer, words
 from pygments import token
 
+# Due to the handling of string interpolation, we have a few states that are
+# almost identical to the root state, but differ in the handling of `}`.
+# Therefore we extract the common tokens here.
+_root_base = [
+    (r"#!.*?$", token.Comment.Hashbang),
+    (r"//.*?$", token.Comment),
+    (r'f"""', token.String, "format_triple"),
+    (r'"""', token.String, "string_triple"),
+    (r'f"', token.String, "format_double"),
+    (r'"', token.String, "string_double"),
+    # Note, the `}` we handle in each of the specializations of this state.
+    (r"0b[01_]+", token.Number.Bin),
+    (r"0x[0-9a-fA-F_]+", token.Number.Hex),
+    (r"[0-9_]+(\.[0-9_]+)?([eE][+-]?[0-9_]+)?", token.Number),
+    # In the Rust lexer, there is one state for identifiers, and in
+    # there we recognize the keywords. We don't recognize builtins at
+    # all in the Rust lexer. Here, we do split all those out by token
+    # type.
+    (
+        words(
+            (
+                "and",
+                "else",
+                "false",
+                "for",
+                "if",
+                "in",
+                "let",
+                "not",
+                "null",
+                "or",
+                "then",
+                "true",
+            ),
+            suffix=r"\b",
+        ),
+        token.Keyword,
+    ),
+    (
+        words(
+            (
+                "contains",
+                "get",
+                "len",
+            ),
+            suffix=r"\b",
+        ),
+        token.Name.Builtin,
+    ),
+    (r"[_a-z][_a-z0-9-]*", token.Name),
+    (r"\s+", token.Whitespace),
+    # In the Rust lexer the punctuation is split out, and then further
+    # into digraphs and monographs. Here we instead split them out by
+    # token type.
+    (r"<=|>=|==|!=|<|>|\+|-|\*|/|\|", token.Operator),
+    (r"[)(\]\[=,.:;]", token.Token),
+    (r"{", token.Token, "in_brace"),
+    (r"#", token.Error),
+]
+
 
 class RclLexer(RegexLexer):
     """
@@ -27,74 +87,44 @@ class RclLexer(RegexLexer):
     tokens = {
         # The root state here corresponds to `Lexer::next` in Rust.
         "root": [
-            (r"#!.*?$", token.Comment.Hashbang),
-            (r"//.*?$", token.Comment),
-            (r'f"""', token.String, "format_triple_open"),
-            (r'"""', token.String, "string_triple"),
-            (r'f"', token.String, "format_double_open"),
-            (r'"', token.String, "string_double"),
-            # TODO: Handle the }
-            (r"0b[01_]+", token.Number.Bin),
-            (r"0x[0-9a-fA-F_]+", token.Number.Hex),
-            (r"[0-9_]+(\.[0-9_]+)?([eE][+-]?[0-9_]+)?", token.Number),
-            # In the Rust lexer, there is one state for identifiers, and in
-            # there we recognize the keywords. We don't recognize builtins at
-            # all in the Rust lexer. Here, we do split all those out by token
-            # type.
-            (
-                words(
-                    (
-                        "and",
-                        "else",
-                        "false",
-                        "for",
-                        "if",
-                        "in",
-                        "let",
-                        "not",
-                        "null",
-                        "or",
-                        "then",
-                        "true",
-                    ),
-                    suffix=r"\b",
-                ),
-                token.Keyword,
-            ),
-            (
-                words(
-                    (
-                        "contains",
-                        "get",
-                        "len",
-                    ),
-                    suffix=r"\b",
-                ),
-                token.Name.Builtin,
-            ),
-            (r"[_a-z][_a-z0-9-]*", token.Name),
-            (r"\s+", token.Whitespace),
-            # In the Rust lexer the punctuation is split out, and then further
-            # into digraphs and monographs. Here we instead split them out by
-            # token type.
-            (r"<=|>=|==|!=|<|>|\+|-|\*|/|\|", token.Operator),
-            (r"[)(}{\]\[=,.:;]", token.Token),
-            (r"#", token.Error),
+            (r"}", token.Error),
+            *_root_base,
         ],
-        "format_double_open": [],
-        "format_triple_open": [],
-        "string_double": [
-            (r'[^\\"]+', token.String),
-            (r"\\", token.String.Escape, "escape"),
+        "in_brace": [
+            (r"}", token.Token, "#pop"),
+            *_root_base,
+        ],
+        "in_interpolation": [
+            (r"}", token.String.Interpol, "#pop"),
+            *_root_base,
+        ],
+        "format_double": [
+            (r'[^\\"{]+', token.String),
             (r'"', token.String, "#pop"),
+            (r"{", token.String.Interpol, "in_interpolation"),
+            (r"\\", token.String.Escape, "escape"),
         ],
-        "string_triple": [
-            (r'[^\\"]+', token.String),
+        "format_triple": [
+            (r'[^\\"{]+', token.String),
+            (r'"""', token.String, "#pop"),
             # Only """ ends the string, but " cannot occur in the above state,
             # so list those two explicitly.
             (r'""|"', token.String),
             (r"\\", token.String.Escape, "escape"),
+            (r"{", token.String.Interpol, "in_interpolation"),
+        ],
+        "string_double": [
+            (r'[^\\"]+', token.String),
+            (r'"', token.String, "#pop"),
+            (r"\\", token.String.Escape, "escape"),
+        ],
+        "string_triple": [
+            (r'[^\\"]+', token.String),
             (r'"""', token.String, "#pop"),
+            # Only """ ends the string, but " cannot occur in the above state,
+            # so list those two explicitly.
+            (r'""|"', token.String),
+            (r"\\", token.String.Escape, "escape"),
         ],
         "escape": [
             (r'["\\/bfnrt{]', token.String.Escape, "#pop"),

--- a/etc/pygments/rcl.py
+++ b/etc/pygments/rcl.py
@@ -7,11 +7,78 @@
 # you may not use this file except in compliance with the License.
 # A copy of the License has been included in the root of the repository.
 
-from pygments.lexer import RegexLexer
-from pygments.token import Text
+from pygments.lexer import RegexLexer, words
+from pygments import token
 
 
 class RclLexer(RegexLexer):
+    """
+    This lexer should mirror the lexer in src/lexer.rs.
+    """
+
     name = "RCL"
     aliases = ["rcl"]
     filenames = ["*.rcl"]
+
+    tokens = {
+        # The root state here corresponds to `Lexer::next` in Rust.
+        "root": [
+            (r"#!.*?$", token.Comment.Hashbang),
+            (r"//.*?$", token.Comment),
+            (r'f"""', token.String, "format_triple_open"),
+            (r'"""', token.String, "triple_open"),
+            (r'f"', token.String, "format_double_open"),
+            (r'"', token.String, "double_open"),
+            # TODO: Handle the }
+            (r"0b[01_]+", token.Number.Bin),
+            (r"0x[0-9a-fA-F_]+", token.Number.Hex),
+            (r"[0-9_]+(\.[0-9_]+)?([eE][+-]?[0-9_]+)?", token.Number),
+            # In the Rust lexer, there is one state for identifiers, and in
+            # there we recognize the keywords. We don't recognize builtins at
+            # all in the Rust lexer. Here, we do split all those out by token
+            # type.
+            (
+                words(
+                    (
+                        "and",
+                        "else",
+                        "false",
+                        "for",
+                        "if",
+                        "in",
+                        "let",
+                        "not",
+                        "null",
+                        "or",
+                        "then",
+                        "true",
+                    ),
+                    suffix=r"\b",
+                ),
+                token.Keyword,
+            ),
+            (
+                words(
+                    (
+                        "contains",
+                        "get",
+                        "len",
+                    ),
+                    suffix=r"\b",
+                ),
+                token.Name.Builtin,
+            ),
+            (r"[_a-z][_a-z0-9-]*", token.Name),
+            (r"\s+", token.Whitespace),
+            # In the Rust lexer the punctuation is split out, and then further
+            # into digraphs and monographs. Here we instead split them out by
+            # token type.
+            (r"<=|>=|==|!=|<|>|\+|-|\*|/|\|", token.Operator),
+            (r"[)(}{\]\[=,.:;]", token.Token),
+            (r"#", token.Error),
+        ],
+        "format_double_open": [],
+        "format_triple_open": [],
+        "double_open": [],
+        "triple_open": [],
+    }

--- a/etc/pygments/rcl.py
+++ b/etc/pygments/rcl.py
@@ -14,6 +14,8 @@
 from pygments.lexer import RegexLexer, words
 from pygments import token
 
+__all__ = ["RclLexer"]
+
 # Due to the handling of string interpolation, we have a few states that are
 # almost identical to the root state, but differ in the handling of `}`.
 # Therefore we extract the common tokens here.
@@ -64,7 +66,10 @@ _root_base = [
         token.Name.Builtin,
     ),
     (r"[_a-z][_a-z0-9-]*", token.Name),
-    (r"\s+", token.Whitespace),
+    # There is a dedicated whitespace token, but if we use it, the html output
+    # (and console output too) gets very polluted, so make whitespace a regular
+    # unclassified token.
+    (r"\s+", token.Token),
     # In the Rust lexer the punctuation is split out, and then further
     # into digraphs and monographs. Here we instead split them out by
     # token type.

--- a/flake.nix
+++ b/flake.nix
@@ -146,9 +146,7 @@
 
               typecheckPython = pkgs.runCommand
                 "check-typecheck-python"
-                # TODO: Should import pythonEnv here for the types.
-                # This will be a good test if the flake check works.
-                { buildInputs = [ pkgs.mypy ]; }
+                { buildInputs = [ pythonEnv ]; }
                 ''
                 mypy --strict ${pythonSources}
                 touch $out

--- a/golden/run.py
+++ b/golden/run.py
@@ -16,8 +16,8 @@ A test runner for running the golden tests.
 
 The runner takes golden input files, splits them into inputs and expectations,
 and then prints whether they match. Inputs and expectations are separated by a
-a line that contains "# output:". Blank lines preceding it are not considered
-Part of the input.
+line that contains "# output:". Blank lines preceding it are not considered part
+of the input.
 
 SYNOPSIS
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,6 +8,7 @@ theme:
   custom_dir: docs/theme
 
 markdown_extensions:
+  - codehilite
   - footnotes
   - toc:
       permalink: true

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -29,4 +29,5 @@ nav:
       - "rcl format": "rcl_format.md"
       - "rcl highlight": "rcl_highlight.md"
       - "rcl query": "rcl_query.md"
-  - "Development": "development.md"
+  - "Development":
+      - "Testing": "testing.md"

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -14,7 +14,7 @@ pub type Result<T> = std::result::Result<T, ParseError>;
 ///
 /// Yes, the names _double_ and _triple_ are slightly misleading because the
 /// triple variant has three times as many quotes as the double one. _Double_
-/// refers to the double quote charater (`"` as opposed to `'`) while _triple_
+/// refers to the double quote character (`"` as opposed to `'`) while _triple_
 /// refers to the number of such characters.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum QuoteStyle {


### PR DESCRIPTION
This adds a Pygments lexer, which is then used by MkDocs for syntax highlighting in the manual.

It would be nice to add a fuzzer or at least some verification against the goldens that tests that the Python and Rust version agree, but the machinery for that output does not yet exist. Also, they currently do not agree, because `rcl highlight` currently does not highlight escape sequences or hole boundaries specially.