### PR TITLE
Add support for assertions and trace

### DIFF
--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -220,3 +220,46 @@ let large_numbers = [100, 200, 300];
 // Evaluates to:
 [1, 2, 3, 10, 100, 200, 300]
 ```
+
+## Assertions
+
+You can use assertions in expressions and inside comprehensions:
+
+```rcl
+// Expression form:
+assert condition, "Message for when the assertion fails.";
+body
+
+// Comprehension form:
+[
+  for widget in widgets:
+  assert widget.is_valid(), f"Widget {widget.id} is invalid.";
+  widget
+]
+```
+
+The message is mandatory (unlike in Python). When the assertion fails,
+evaluation aborts with the given message. The message does not have to be a
+string, it can be an arbitrary value. When the assertion succeeds, the message
+does not get evaluated at all.
+
+## Debug tracing
+
+In larger programs it can sometimes be useful to print what is going on during
+evaluation. However, RCL is a purely functional language without side effects;
+the only output it can produce is the final value. To still aid debugging,
+`trace` acts as an escape hatch: it has the side effect of printing a value to
+stderr during evaluation.
+
+Like assertions, you can use `trace` in expressions and inside comprehensions:
+
+```rcl
+// Expression form:
+trace "Value that gets printed just before we evaluate `body`.";
+body
+
+// Comprehension form:
+let widget_ids = [for widget in widgets: trace widget; widget.id];
+```
+
+The message does not have to be a string, it can be an arbitrary value.

--- a/etc/pygments/rcl.py
+++ b/etc/pygments/rcl.py
@@ -36,6 +36,7 @@ _root_base = [
         words(
             (
                 "and",
+                "assert",
                 "else",
                 "false",
                 "for",
@@ -46,6 +47,7 @@ _root_base = [
                 "null",
                 "or",
                 "then",
+                "trace",
                 "true",
             ),
             suffix=r"\b",

--- a/etc/rcl.vim/syntax/rcl.vim
+++ b/etc/rcl.vim/syntax/rcl.vim
@@ -11,7 +11,8 @@ syn keyword rclConditional  if then else
 syn keyword rclRepeat       for
 syn keyword rclOperator     and not or
 syn keyword rclKeyword      in let
-syn cluster rclKeyword      contains=rclBoolean,rclConditional,rclRepeat,rclOperator,rclKeyword
+syn keyword rclException    assert trace
+syn cluster rclKeyword      contains=rclBoolean,rclConditional,rclRepeat,rclOperator,rclKeyword,rclException
 
 syn match rclOperator '<='
 syn match rclOperator '>='

--- a/etc/rcl.vim/syntax/rcl.vim
+++ b/etc/rcl.vim/syntax/rcl.vim
@@ -59,6 +59,7 @@ highlight link rclRepeat      Repeat
 highlight link rclOperator    Operator
 highlight link rclNull        Keyword
 highlight link rclKeyword     Keyword
+highlight link rclException   Keyword
 highlight link rclComment     Comment
 highlight link rclTodo        Todo
 highlight link rclBuiltin     Function

--- a/fuzz/dictionary.txt
+++ b/fuzz/dictionary.txt
@@ -1,5 +1,6 @@
 # Keywords
 "and"
+"assert"
 "else"
 "false"
 "for"
@@ -9,6 +10,7 @@
 "not"
 "or"
 "then"
+"trace"
 "true"
 
 # Operators

--- a/golden/error/parse_assert_no_comma.test
+++ b/golden/error/parse_assert_no_comma.test
@@ -1,11 +1,9 @@
-assert false;
+assert false
 0
 
 # output:
- --> stdin:1:12
+ --> stdin:2:0
   |
-1 | assert false;
-  |             ^
+2 | 0
+  | ^
 Error: Expected ',' here between the assertion condition and message.
-
-Help: An assertion has the form 'assert <condition>, <message>;'. The message is not optional.

--- a/golden/error/parse_assert_no_comma.test
+++ b/golden/error/parse_assert_no_comma.test
@@ -1,0 +1,11 @@
+assert false;
+0
+
+# output:
+ --> stdin:1:12
+  |
+1 | assert false;
+  |             ^
+Error: Expected ',' here between the assertion condition and message.
+
+Help: An assertion has the form 'assert <condition>, <message>;'. The message is not optional.

--- a/golden/error/parse_assert_semicolon.test
+++ b/golden/error/parse_assert_semicolon.test
@@ -1,0 +1,11 @@
+assert false;
+0
+
+# output:
+ --> stdin:1:12
+  |
+1 | assert false;
+  |             ^
+Error: Expected ',' here between the assertion condition and message.
+
+Help: An assertion has the form 'assert <condition>, <message>;'. The message is not optional.

--- a/golden/error/runtime_assertion_failure.test
+++ b/golden/error/runtime_assertion_failure.test
@@ -1,0 +1,10 @@
+assert false, "This assertion should fail.";
+0
+
+# output:
+Assertion failed: String("This assertion should fail.")
+ --> stdin:1:0
+  |
+1 | assert false, "This assertion should fail.";
+  | ^~~~~~
+Error: Assertion failed.

--- a/golden/error/runtime_assertion_failure.test
+++ b/golden/error/runtime_assertion_failure.test
@@ -3,8 +3,8 @@ assert false, "This assertion should fail.";
 
 # output:
 Assertion failed: String("This assertion should fail.")
- --> stdin:1:0
+ --> stdin:1:7
   |
 1 | assert false, "This assertion should fail.";
-  | ^~~~~~
+  |        ^~~~~
 Error: Assertion failed.

--- a/golden/error/runtime_assertion_failure.test
+++ b/golden/error/runtime_assertion_failure.test
@@ -1,10 +1,11 @@
+assert true, "This assertion should pass.";
 assert false, "This assertion should fail.";
 0
 
 # output:
 Assertion failed: String("This assertion should fail.")
- --> stdin:1:7
+ --> stdin:2:7
   |
-1 | assert false, "This assertion should fail.";
+2 | assert false, "This assertion should fail.";
   |        ^~~~~
 Error: Assertion failed.

--- a/golden/error/runtime_assertion_not_bool.test
+++ b/golden/error/runtime_assertion_not_bool.test
@@ -2,8 +2,8 @@ assert 0, "The condition should be a boolean.";
 0
 
 # output:
- --> stdin:1:0
+ --> stdin:1:7
   |
 1 | assert 0, "The condition should be a boolean.";
-  | ^~~~~~
+  |        ^
 Error: Assertion condition must evaluate to a boolean.

--- a/golden/error/runtime_assertion_not_bool.test
+++ b/golden/error/runtime_assertion_not_bool.test
@@ -1,0 +1,9 @@
+assert 0, "The condition should be a boolean.";
+0
+
+# output:
+ --> stdin:1:0
+  |
+1 | assert 0, "The condition should be a boolean.";
+  | ^~~~~~
+Error: Assertion condition must evaluate to a boolean.

--- a/golden/fmt/assert_trace.test
+++ b/golden/fmt/assert_trace.test
@@ -1,0 +1,22 @@
+assert true == true, "The two true booleans should be equal";
+trace "Some short message";
+
+assert this_is_a_much_longer_assertion_that_does_not_fit(), [
+  "If you include its error message."
+];
+trace f"And this is a much longer trace message which has a hole in it {
+0
+} but nonetheless should not be line-wrapped.";
+
+0
+
+# output:
+assert true == true, "The two true booleans should be equal";
+trace "Some short message";
+
+assert
+  this_is_a_much_longer_assertion_that_does_not_fit(),
+  ["If you include its error message."];
+trace f"And this is a much longer trace message which has a hole in it {0} but nonetheless should not be line-wrapped.";
+
+0

--- a/golden/fmt/list_comprehension.test
+++ b/golden/fmt/list_comprehension.test
@@ -6,6 +6,17 @@ let tall = [
     x.hydrocoptics.marzlevanes; marzlevanes,
 ];
 let wide = [for x in tall: if x.active_on_tuesday(): x.inner];
+// The next one demonstrates that we should be able to have two comprehensions
+// in a collection, and if the comprehension itself fits, it should not
+// line-wrap.
+let double_comprehension = [
+  for m in extract_marzlevanes():
+  if m.is_hydrocoptic():
+  m.frobnicated(),
+  for h in extract_hydrocoptics():
+  if h.is_marzlevane():
+  h.frobnicated(),
+];
 // TODO: All-or-nothing let chain wide or tall.
 let b = [
   1,
@@ -21,5 +32,12 @@ let tall = [
   marzlevanes
 ];
 let wide = [for x in tall: if x.active_on_tuesday(): x.inner];
+// The next one demonstrates that we should be able to have two comprehensions
+// in a collection, and if the comprehension itself fits, it should not
+// line-wrap.
+let double_comprehension = [
+  for m in extract_marzlevanes(): if m.is_hydrocoptic(): m.frobnicated(),
+  for h in extract_hydrocoptics(): if h.is_marzlevane(): h.frobnicated(),
+];
 // TODO: All-or-nothing let chain wide or tall.
 let b = [1]; a + b

--- a/golden/fmt/list_comprehension.test
+++ b/golden/fmt/list_comprehension.test
@@ -17,7 +17,8 @@ a + b
 let tall = [
   for x in some_very_long_function_name():
   if x.frobnicator.is_activated_on("Tuesday"):
-  let marzlevanes = x.hydrocoptics.marzlevanes; marzlevanes
+  let marzlevanes = x.hydrocoptics.marzlevanes;
+  marzlevanes
 ];
 let wide = [for x in tall: if x.active_on_tuesday(): x.inner];
 // TODO: All-or-nothing let chain wide or tall.

--- a/golden/fmt/list_comprehension.test
+++ b/golden/fmt/list_comprehension.test
@@ -17,8 +17,7 @@ a + b
 let tall = [
   for x in some_very_long_function_name():
   if x.frobnicator.is_activated_on("Tuesday"):
-  let marzlevanes = x.hydrocoptics.marzlevanes;
-  marzlevanes
+  let marzlevanes = x.hydrocoptics.marzlevanes; marzlevanes
 ];
 let wide = [for x in tall: if x.active_on_tuesday(): x.inner];
 // TODO: All-or-nothing let chain wide or tall.

--- a/golden/fmt/nested_let.test
+++ b/golden/fmt/nested_let.test
@@ -1,0 +1,17 @@
+{
+  outer_thing = let inner_thing = some_long_expression
+      (
+          "with some",
+          "long input"
+      );
+      inner_thing;
+  outer_second_thing = 2;
+}
+
+# output:
+{
+  outer_thing =
+    let inner_thing = some_long_expression("with some", "long input");
+    inner_thing;
+  outer_second_thing = 2;
+}

--- a/golden/json/trace.test
+++ b/golden/json/trace.test
@@ -1,0 +1,5 @@
+trace "Value to trace."; 0
+
+# output:
+0
+Trace from d0[0..5]: String("Value to trace.")

--- a/src/abstraction.rs
+++ b/src/abstraction.rs
@@ -118,12 +118,21 @@ impl<'a> Abstractor<'a> {
                 value: Box::new(self.expr(value)?),
             },
             CStmt::Assert {
-                condition, message, ..
+                assert_span,
+                condition,
+                message,
+                ..
             } => AStmt::Assert {
+                assert_span: *assert_span,
                 condition: Box::new(self.expr(condition)?),
                 message: Box::new(self.expr(message)?),
             },
-            CStmt::Trace { message, .. } => AStmt::Trace {
+            CStmt::Trace {
+                trace_span,
+                message,
+                ..
+            } => AStmt::Trace {
+                trace_span: *trace_span,
                 message: Box::new(self.expr(message)?),
             },
         };

--- a/src/abstraction.rs
+++ b/src/abstraction.rs
@@ -15,9 +15,9 @@
 
 use std::rc::Rc;
 
-use crate::ast::{Expr as AExpr, FormatFragment, Seq as ASeq, Yield};
+use crate::ast::{Expr as AExpr, FormatFragment, Seq as ASeq, Stmt as AStmt, Yield};
 use crate::cst::Prefixed;
-use crate::cst::{Expr as CExpr, FormatHole, Seq as CSeq};
+use crate::cst::{Expr as CExpr, FormatHole, Seq as CSeq, Stmt as CStmt};
 use crate::error::{IntoParseError, Result};
 use crate::lexer::QuoteStyle;
 use crate::source::Span;
@@ -110,14 +110,31 @@ impl<'a> Abstractor<'a> {
         Ok(AExpr::Format(fragments?))
     }
 
+    /// Abstract a statement.
+    pub fn stmt(&self, stmt: &CStmt) -> Result<AStmt> {
+        let result = match stmt {
+            CStmt::Let { ident, value, .. } => AStmt::Let {
+                ident: ident.resolve(self.input).into(),
+                value: Box::new(self.expr(value)?),
+            },
+            CStmt::Assert {
+                condition, message, ..
+            } => AStmt::Assert {
+                condition: Box::new(self.expr(condition)?),
+                message: Box::new(self.expr(message)?),
+            },
+            CStmt::Trace { message, .. } => AStmt::Trace {
+                message: Box::new(self.expr(message)?),
+            },
+        };
+        Ok(result)
+    }
+
     /// Abstract an expression.
     pub fn expr(&self, expr: &CExpr) -> Result<AExpr> {
         let result = match expr {
-            CExpr::Let {
-                ident, value, body, ..
-            } => AExpr::Let {
-                ident: ident.resolve(self.input).into(),
-                value: Box::new(self.expr(value)?),
+            CExpr::Stmt { stmt, body, .. } => AExpr::Stmt {
+                stmt: self.stmt(stmt)?,
                 body: Box::new(self.expr(&body.inner)?),
             },
 
@@ -297,11 +314,8 @@ impl<'a> Abstractor<'a> {
                 })
             }
 
-            CSeq::Let {
-                ident, value, body, ..
-            } => ASeq::Let {
-                ident: ident.resolve(self.input).into(),
-                value: Box::new(self.expr(value)?),
+            CSeq::Stmt { stmt, body, .. } => ASeq::Stmt {
+                stmt: self.stmt(stmt)?,
                 body: Box::new(self.seq(&body.inner)?),
             },
 

--- a/src/abstraction.rs
+++ b/src/abstraction.rs
@@ -118,12 +118,12 @@ impl<'a> Abstractor<'a> {
                 value: Box::new(self.expr(value)?),
             },
             CStmt::Assert {
-                assert_span,
+                condition_span,
                 condition,
                 message,
                 ..
             } => AStmt::Assert {
-                assert_span: *assert_span,
+                condition_span: *condition_span,
                 condition: Box::new(self.expr(condition)?),
                 message: Box::new(self.expr(message)?),
             },

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -66,12 +66,18 @@ pub enum Stmt {
 
     /// Evaluate to the body if true, fail with the message if false.
     Assert {
+        /// The span of the `assert` keyword. Here we report the error from.
+        assert_span: Span,
         condition: Box<Expr>,
         message: Box<Expr>,
     },
 
     /// Print the message for debugging;
-    Trace { message: Box<Expr> },
+    Trace {
+        /// The span of the `trace` keyword. Here we report the trace from.
+        trace_span: Span,
+        message: Box<Expr>,
+    },
 }
 
 /// An expression.

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -72,7 +72,7 @@ pub enum Stmt {
         message: Box<Expr>,
     },
 
-    /// Print the message for debugging;
+    /// Print the message for debugging.
     Trace {
         /// The span of the `trace` keyword. Here we report the trace from.
         trace_span: Span,

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -53,15 +53,32 @@ pub struct FormatFragment {
     pub body: Expr,
 }
 
+/// A statement-like expression.
+///
+/// RCL does not have statements that have side effects, but it does have
+/// constructs that look like statements, which evaluate a left-hand side,
+/// and then evaluate a body in a modified environment. For lack of a better
+/// name, we do call those _statements_.
+#[derive(Debug)]
+pub enum Stmt {
+    /// A let-binding.
+    Let { ident: Ident, value: Box<Expr> },
+
+    /// Evaluate to the body if true, fail with the message if false.
+    Assert {
+        condition: Box<Expr>,
+        message: Box<Expr>,
+    },
+
+    /// Print the message for debugging;
+    Trace { message: Box<Expr> },
+}
+
 /// An expression.
 #[derive(Debug)]
 pub enum Expr {
-    /// A let-binding. First is the bound value, then the result expression.
-    Let {
-        ident: Ident,
-        value: Box<Expr>,
-        body: Box<Expr>,
-    },
+    /// A statement-like expression.
+    Stmt { stmt: Stmt, body: Box<Expr> },
 
     /// A dict or set literal (depending on the element types) enclosed in `{}`.
     BraceLit(Vec<Seq>),
@@ -152,15 +169,11 @@ pub enum Seq {
     /// Yield a value or key-value pair.
     Yield(Yield),
 
-    /// Let in the middle of a sequence literal.
+    /// A statement in the middle of a sequence literal.
     ///
-    /// This is syntactically different from a let before an expression, because
-    /// associations are not first-class values.
-    Let {
-        ident: Ident,
-        value: Box<Expr>,
-        body: Box<Seq>,
-    },
+    /// This is syntactically different from a statement before an expression,
+    /// because associations are not first-class values.
+    Stmt { stmt: Stmt, body: Box<Seq> },
 
     /// Loop over the collection, binding the values to `idents`.
     For {
@@ -184,7 +197,7 @@ impl Seq {
     pub fn innermost(&self) -> &Yield {
         match self {
             Seq::Yield(y) => y,
-            Seq::Let { body, .. } => body.innermost(),
+            Seq::Stmt { body, .. } => body.innermost(),
             Seq::For { body, .. } => body.innermost(),
             Seq::If { body, .. } => body.innermost(),
         }

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -66,8 +66,8 @@ pub enum Stmt {
 
     /// Evaluate to the body if true, fail with the message if false.
     Assert {
-        /// The span of the `assert` keyword. Here we report the error from.
-        assert_span: Span,
+        /// The span of the condition. Here we report the error from.
+        condition_span: Span,
         condition: Box<Expr>,
         message: Box<Expr>,
     },

--- a/src/cst.rs
+++ b/src/cst.rs
@@ -118,7 +118,6 @@ pub enum Stmt {
 
     /// An assertion with a failure message.
     Assert {
-        assert_span: Span,
         condition_span: Span,
         condition: Box<Expr>,
         message_span: Span,

--- a/src/cst.rs
+++ b/src/cst.rs
@@ -118,6 +118,7 @@ pub enum Stmt {
 
     /// An assertion with a failure message.
     Assert {
+        assert_span: Span,
         condition_span: Span,
         condition: Box<Expr>,
         message_span: Span,
@@ -126,6 +127,7 @@ pub enum Stmt {
 
     /// Trace prints the message (for debugging) and then evaluates to the body.
     Trace {
+        trace_span: Span,
         message_span: Span,
         message: Box<Expr>,
     },

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -386,7 +386,10 @@ fn eval_stmt(env: &mut Env, stmt: &Stmt) -> Result<()> {
                     let message = eval(env, message_expr)?;
                     // TODO: Include the message in the error. We need a way to
                     // attach values in addition to source locations ...
+                    #[cfg(not(fuzzing))]
                     eprintln!("Assertion failed: {message:?}");
+                    #[cfg(fuzzing)]
+                    let _ = message;
                     return Err(assert_span.error("Assertion failed.").into());
                 }
                 _ => {
@@ -403,7 +406,10 @@ fn eval_stmt(env: &mut Env, stmt: &Stmt) -> Result<()> {
             // TODO: Implement proper reporting, format in the same way as
             // errors, pretty-print the value, ...
             let message = eval(env, message_expr)?;
+            #[cfg(not(fuzzing))]
             eprintln!("Trace from {trace_span:?}: {message:?}");
+            #[cfg(fuzzing)]
+            let _ = (message, trace_span);
         }
     }
     Ok(())

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -373,7 +373,7 @@ fn eval_stmt(env: &mut Env, stmt: &Stmt) -> Result<()> {
             env.push(ident.clone(), v);
         }
         Stmt::Assert {
-            assert_span,
+            condition_span,
             condition,
             message: message_expr,
         } => {
@@ -390,11 +390,12 @@ fn eval_stmt(env: &mut Env, stmt: &Stmt) -> Result<()> {
                     eprintln!("Assertion failed: {message:?}");
                     #[cfg(fuzzing)]
                     let _ = message;
-                    return Err(assert_span.error("Assertion failed.").into());
+                    return Err(condition_span.error("Assertion failed.").into());
                 }
                 _ => {
                     // TODO: Report a proper type error.
-                    let err = assert_span.error("Assertion condition must evaluate to a boolean.");
+                    let err =
+                        condition_span.error("Assertion condition must evaluate to a boolean.");
                     return Err(err.into());
                 }
             }

--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -225,10 +225,12 @@ impl<'a> Formatter<'a> {
         match expr {
             Expr::Stmt { stmt, body, .. } => {
                 group! {
-                    self.stmt(stmt)
-                    Doc::Sep
-                    self.non_code(&body.prefix)
-                    self.expr(&body.inner)
+                    flush_indent! {
+                        self.stmt(stmt)
+                        Doc::Sep
+                        self.non_code(&body.prefix)
+                        self.expr(&body.inner)
+                    }
                 }
             }
 
@@ -429,7 +431,7 @@ impl<'a> Formatter<'a> {
             }
 
             Seq::Stmt { stmt, body, .. } => {
-                group! {
+                concat! {
                     self.stmt(stmt)
                     Doc::Sep
                     self.non_code(&body.prefix)

--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -32,17 +32,6 @@ struct Formatter<'a> {
     input: &'a str,
 }
 
-/// How to terminate an item in a collection literal.
-#[derive(Copy, Clone, Debug)]
-enum Separator {
-    /// Unconditionally append a separator.
-    Unconditional,
-    /// Append the separator only in tall mode.
-    Trailer,
-    /// Do not append a separator.
-    None,
-}
-
 impl<'a> Formatter<'a> {
     pub fn new(input: &'a str) -> Self {
         Self { input }
@@ -376,30 +365,30 @@ impl<'a> Formatter<'a> {
         }
     }
 
-    /// Emit the separator according to the termination mode.
-    pub fn separator(&self, separator: &'a str, mode: Separator) -> Doc<'a> {
-        match mode {
-            Separator::Unconditional => Doc::str(separator),
-            Separator::Trailer => Doc::tall(separator),
-            Separator::None => Doc::empty(),
-        }
-    }
-
     pub fn seqs(&self, elements: &[Prefixed<Seq>]) -> Doc<'a> {
         let mut result = Vec::new();
         for (i, elem) in elements.iter().enumerate() {
+            let (elem_doc, sep_str) = self.seq(&elem.inner);
+
+            // We wrap the inner Seq in a group, so you can have a collection
+            // that consists of multiple comprehensions, and each one fits on
+            // a line, so they are all formatted wide, but the collection itself
+            // is formatted tall.
+            result.push(self.non_code(&elem.prefix));
+            result.push(group! { elem_doc });
+
             let is_last = i + 1 == elements.len();
-            let sep_mode = match i {
+            let sep_doc = match i {
                 // For collections that contain a single seq, do not add a
                 // separator, even when they are multi-line. It makes
                 // comprehensions look weird, which are regularly multi-line but
                 // only rarely are there multiple seqs in the collection.
-                _ if elements.len() == 1 => Separator::None,
-                _ if is_last => Separator::Trailer,
-                _ => Separator::Unconditional,
+                _ if elements.len() == 1 => Doc::empty(),
+                _ if is_last => Doc::tall(sep_str),
+                _ => Doc::str(sep_str),
             };
-            result.push(self.non_code(&elem.prefix));
-            result.push(self.seq(&elem.inner, sep_mode));
+            result.push(sep_doc);
+
             if !is_last {
                 result.push(Doc::Sep)
             }
@@ -407,36 +396,28 @@ impl<'a> Formatter<'a> {
         Doc::Concat(result)
     }
 
-    pub fn seq(&self, seq: &Seq, sep_mode: Separator) -> Doc<'a> {
+    /// Format a sequence. Return that and the trailing separator.
+    pub fn seq(&self, seq: &Seq) -> (Doc<'a>, &'static str) {
         match seq {
-            Seq::Elem { value, .. } => {
-                concat! {
-                    self.expr(value)
-                    self.separator(",", sep_mode)
-                }
-            }
+            Seq::Elem { value, .. } => (self.expr(value), ","),
 
             Seq::AssocExpr { field, value, .. } => {
-                concat! {
-                    self.expr(field) ": " self.expr(value)
-                    self.separator(",", sep_mode)
-                }
+                (concat! { self.expr(field) ": " self.expr(value) }, ",")
             }
 
             Seq::AssocIdent { field, value, .. } => {
-                concat! {
-                    self.span(*field) " = " self.expr(value)
-                    self.separator(";", sep_mode)
-                }
+                (concat! { self.span(*field) " = " self.expr(value) }, ";")
             }
 
             Seq::Stmt { stmt, body, .. } => {
-                concat! {
+                let (body_doc, sep) = self.seq(&body.inner);
+                let result = concat! {
                     self.stmt(stmt)
                     Doc::Sep
                     self.non_code(&body.prefix)
-                    self.seq(&body.inner, sep_mode)
-                }
+                    body_doc
+                };
+                (result, sep)
             }
 
             Seq::For {
@@ -445,7 +426,8 @@ impl<'a> Formatter<'a> {
                 body,
                 ..
             } => {
-                concat! {
+                let (body_doc, sep) = self.seq(&body.inner);
+                let result = concat! {
                     "for "
                     // TODO: This does not use a proper sep, which means we
                     // cannot break this over multiple lines. But maybe that's
@@ -459,21 +441,24 @@ impl<'a> Formatter<'a> {
                     ":"
                     Doc::Sep
                     self.non_code(&body.prefix)
-                    self.seq(&body.inner, sep_mode)
-                }
+                    body_doc
+                };
+                (result, sep)
             }
 
             Seq::If {
                 condition, body, ..
             } => {
-                concat! {
+                let (body_doc, sep) = self.seq(&body.inner);
+                let result = concat! {
                     "if "
                     self.expr(condition)
                     ":"
                     Doc::Sep
                     self.non_code(&body.prefix)
-                    self.seq(&body.inner, sep_mode)
-                }
+                    body_doc
+                };
+                (result, sep)
             }
         }
     }

--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -192,9 +192,10 @@ impl<'a> Formatter<'a> {
                 condition, message, ..
             } => {
                 concat! {
-                    "assert "
+                    "assert"
                     group! {
-                        flush_indent! {
+                        indent! {
+                            Doc::Sep
                             self.expr(condition)
                             ","
                             Doc::Sep

--- a/src/grammar.y
+++ b/src/grammar.y
@@ -19,11 +19,11 @@
 
 expr
   : expr_op
-  | expr_let
+  | expr_stmt
   | expr_if
   ;
 
-expr_let: "let" IDENT '=' expr ';' expr;
+expr_stmt: stmt expr;
 expr_if: "if" expr "then" expr "else" expr;
 
 // There is no operator precedence, so if there is an operator, its args must
@@ -74,6 +74,12 @@ fstring
   | expr FSTRING_INNER fstring
   ;
 
+stmt
+  : "let" IDENT '=' expr ';'
+  | "assert" expr ',' expr ';'
+  | "trace" expr ';'
+  ;
+
 seqs
   : %empty
   | seq
@@ -87,7 +93,7 @@ seq
   : expr_op
   | expr_op ':' expr
   | IDENT '=' expr ';' seq
-  | "let" IDENT '=' expr ';' seq
+  | stmt seq
   | "for" idents "in" expr ':' seq
   | "if" expr ':' seq
   ;

--- a/src/highlight.rs
+++ b/src/highlight.rs
@@ -31,6 +31,7 @@ fn get_color(token: &Token, token_bytes: &[u8]) -> &'static str {
             _ => reset,
         },
         Token::KwAnd
+        | Token::KwAssert
         | Token::KwElse
         | Token::KwFalse
         | Token::KwFor
@@ -41,6 +42,7 @@ fn get_color(token: &Token, token_bytes: &[u8]) -> &'static str {
         | Token::KwNull
         | Token::KwOr
         | Token::KwThen
+        | Token::KwTrace
         | Token::KwTrue => green,
         _ => blue,
     }

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -82,6 +82,9 @@ pub enum Token {
     /// `and`
     KwAnd,
 
+    /// `assert`
+    KwAssert,
+
     /// `false`
     KwFalse,
 
@@ -111,6 +114,9 @@ pub enum Token {
 
     /// `then`
     KwThen,
+
+    /// `trace`
+    KwTrace,
 
     /// `true`
     KwTrue,
@@ -431,6 +437,7 @@ impl<'a> Lexer<'a> {
         let span = self.take_while(|ch| ch.is_ascii_alphanumeric() || ch == b'_' || ch == b'-');
         let ident = span.resolve(self.input);
         let token = match ident {
+            "assert" => Token::KwAssert,
             "and" => Token::KwAnd,
             "else" => Token::KwElse,
             "false" => Token::KwFalse,
@@ -442,6 +449,7 @@ impl<'a> Lexer<'a> {
             "null" => Token::KwNull,
             "or" => Token::KwOr,
             "then" => Token::KwThen,
+            "trace" => Token::KwTrace,
             "true" => Token::KwTrue,
             _ => Token::Ident,
         };

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -390,7 +390,7 @@ impl<'a> Parser<'a> {
 
     fn parse_stmt_assert(&mut self) -> Result<Stmt> {
         // Consume the `assert` keyword.
-        let assert_ = self.consume();
+        let assert_span = self.consume();
 
         self.skip_non_code()?;
         let (condition_span, condition) = self.parse_expr()?;
@@ -422,11 +422,12 @@ impl<'a> Parser<'a> {
         self.parse_token_with_note(
             Token::Semicolon,
             "Expected ';' here to close the assertion.",
-            assert_,
+            assert_span,
             "Assertion opened here.",
         )?;
 
         let result = Stmt::Assert {
+            assert_span,
             condition_span,
             condition: Box::new(condition),
             message_span,
@@ -468,7 +469,7 @@ impl<'a> Parser<'a> {
 
     fn parse_stmt_trace(&mut self) -> Result<Stmt> {
         // Consume the `trace` keyword.
-        let trace = self.consume();
+        let trace_span = self.consume();
 
         self.skip_non_code()?;
         let (message_span, message) = self.parse_expr()?;
@@ -477,11 +478,12 @@ impl<'a> Parser<'a> {
         self.parse_token_with_note(
             Token::Semicolon,
             "Expected ';' here to close the trace expression.",
-            trace,
+            trace_span,
             "Trace opened here.",
         )?;
 
         let result = Stmt::Trace {
+            trace_span,
             message_span,
             message: Box::new(message),
         };

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -377,7 +377,7 @@ impl<'a> Parser<'a> {
         Ok(result)
     }
 
-    /// If there is a statement under the cursor, parse it.
+    /// Parse the statement under the cursor.
     #[inline]
     fn parse_stmt(&mut self) -> Result<Stmt> {
         match self.peek() {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -427,7 +427,6 @@ impl<'a> Parser<'a> {
         )?;
 
         let result = Stmt::Assert {
-            assert_span,
             condition_span,
             condition: Box::new(condition),
             message_span,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -683,6 +683,13 @@ impl<'a> Parser<'a> {
             if self.peek() == Some(Token::RParen) {
                 // TODO: In this case we lose the prefix that we parsed.
                 // See also the comment in `parse_seqs` below.
+                // TODO: One idea to remediate this, is to make peeking mutable,
+                // and to have anything that asks for the next token skip over
+                // noncode, but store it internally. Then we have another method
+                // to take all the noncode up to that point. It would make
+                // looking a head a bit easier, but it might also cause cases
+                // where we accidentally move comments over items if we are not
+                // careful.
                 return Ok(result.into_boxed_slice());
             }
 


### PR DESCRIPTION
* [x] Add `assert` and `trace` keywords (update all the highlighters, fuzz dictionary, etc.)
* [x] Change CST and AST nodes to include a statement type. Statements are `let`, `assert`, and `trace`. Statements are not like statements in imperative languages; they do not have side effects (to the program at least, `trace` should have the side effect of printing to stderr, but we don't count that one on purpose). They do not mutate the environment, though they produce a new environment for the inner expression to be evaluated in.
* [x] Parse `assert` and `trace`.
* [x] Handle assertions in the evaluator.
* [x] Handle `trace` in the evaluator (maybe for later to do it properly).