### PR TITLE
Add support for indexing into lists

### DIFF
--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -170,6 +170,17 @@ let should_log_verbose =
 
 [pony-ops]: https://tutorial.ponylang.io/expressions/ops.html#precedence
 
+## Indexing
+
+Brackets are used to index into collections. At the moment, only lists are
+supported. Indices must be integers and are 0-based.
+
+```rcl
+let xs = ["Deckard", "Rachael", "Tyrell"];
+xs[0]
+// Evaluates to "Deckard".
+```
+
 ## Comprehensions
 
 Inside collection literals (lists, dicts, and sets), aside from single

--- a/golden/error/runtime_index_dict.test
+++ b/golden/error/runtime_index_dict.test
@@ -1,0 +1,14 @@
+{"not supported yet": 1}["not supported yet"]
+
+# output:
+stdin:1:25
+  ╷
+1 │ {"not supported yet": 1}["not supported yet"]
+  ╵                         ^
+Error: Indexing into a dict is not yet supported.
+
+stdin:1:1
+  ╷
+1 │ {"not supported yet": 1}["not supported yet"]
+  ╵ ^~~~~~~~~~~~~~~~~~~~~~~~
+Note: This is a dict.

--- a/golden/error/runtime_index_not_int.test
+++ b/golden/error/runtime_index_not_int.test
@@ -1,0 +1,9 @@
+let xs = [0, 1, 2];
+xs["invalid"]
+
+# output:
+stdin:2:4
+  ╷
+2 │ xs["invalid"]
+  ╵    ^~~~~~~~~
+Error: Index must be an integer.

--- a/golden/error/runtime_index_not_list.test
+++ b/golden/error/runtime_index_not_list.test
@@ -1,0 +1,14 @@
+true[0]
+
+# output:
+stdin:1:5
+  ╷
+1 │ true[0]
+  ╵     ^
+Error: Indexing is not supported here.
+
+stdin:1:1
+  ╷
+1 │ true[0]
+  ╵ ^~~~
+Note: This value is not a list.

--- a/golden/error/runtime_index_not_list.test
+++ b/golden/error/runtime_index_not_list.test
@@ -11,4 +11,4 @@ stdin:1:1
   ╷
 1 │ true[0]
   ╵ ^~~~
-Note: This value is not a list.
+Note: Expected a list, but found: true.

--- a/golden/error/runtime_index_out_of_bounds.test
+++ b/golden/error/runtime_index_out_of_bounds.test
@@ -1,0 +1,9 @@
+let xs = [0, 1, 2];
+xs[3]
+
+# output:
+stdin:2:4
+  ╷
+2 │ xs[3]
+  ╵    ^
+Error: Index 3 is out of bounds for list of length 3.

--- a/golden/error/runtime_index_string.test
+++ b/golden/error/runtime_index_string.test
@@ -1,0 +1,14 @@
+"not supported yet"[0]
+
+# output:
+stdin:1:20
+  ╷
+1 │ "not supported yet"[0]
+  ╵                    ^
+Error: Indexing into a string is not yet supported.
+
+stdin:1:1
+  ╷
+1 │ "not supported yet"[0]
+  ╵ ^~~~~~~~~~~~~~~~~~~
+Note: This is a string.

--- a/golden/fmt/index_tall.test
+++ b/golden/fmt/index_tall.test
@@ -1,0 +1,17 @@
+[
+  xs[// A comment forces tall mode in indexing.
+  1
+  ], // But usually the brackets are tight.
+  xs[2],
+]
+
+
+# output:
+[
+  xs[
+    // A comment forces tall mode in indexing.
+    1
+  ],
+  // But usually the brackets are tight.
+  xs[2],
+]

--- a/golden/json/list_index.test
+++ b/golden/json/list_index.test
@@ -1,0 +1,4 @@
+let xs = ["a", "b", "c"]; xs[0]
+
+# output:
+"a"

--- a/src/abstraction.rs
+++ b/src/abstraction.rs
@@ -244,11 +244,15 @@ impl<'a> Abstractor<'a> {
             },
 
             CExpr::Index {
+                open,
+                close,
                 collection,
                 collection_span,
                 index,
                 index_span,
             } => AExpr::Index {
+                open: *open,
+                close: *close,
                 collection_span: *collection_span,
                 collection: Box::new(self.expr(collection)?),
                 index_span: *index_span,

--- a/src/abstraction.rs
+++ b/src/abstraction.rs
@@ -247,11 +247,12 @@ impl<'a> Abstractor<'a> {
                 collection,
                 collection_span,
                 index,
+                index_span,
             } => AExpr::Index {
                 collection_span: *collection_span,
                 collection: Box::new(self.expr(collection)?),
-                index_span: index.as_ref().0,
-                index: Box::new(self.expr(&index.as_ref().1.inner)?),
+                index_span: *index_span,
+                index: Box::new(self.expr(&index.inner)?),
             },
 
             CExpr::UnOp { op, op_span, body } => AExpr::UnOp {

--- a/src/abstraction.rs
+++ b/src/abstraction.rs
@@ -243,6 +243,17 @@ impl<'a> Abstractor<'a> {
                     .collect::<Result<Vec<_>>>()?,
             },
 
+            CExpr::Index {
+                collection,
+                collection_span,
+                index,
+            } => AExpr::Index {
+                collection_span: *collection_span,
+                collection: Box::new(self.expr(collection)?),
+                index_span: index.as_ref().0,
+                index: Box::new(self.expr(&index.as_ref().1.inner)?),
+            },
+
             CExpr::UnOp { op, op_span, body } => AExpr::UnOp {
                 op: *op,
                 op_span: *op_span,

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -151,6 +151,10 @@ pub enum Expr {
 
     /// Index into a collection as `collection[index]`.
     Index {
+        /// The opening bracket.
+        open: Span,
+        /// The closing bracket.
+        close: Span,
         collection_span: Span,
         collection: Box<Expr>,
         index_span: Span,

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -149,6 +149,14 @@ pub enum Expr {
         args: Vec<(Span, Expr)>,
     },
 
+    /// Index into a collection as `collection[index]`.
+    Index {
+        collection_span: Span,
+        collection: Box<Expr>,
+        index_span: Span,
+        index: Box<Expr>,
+    },
+
     /// Apply a unary operator.
     UnOp {
         op: UnOp,

--- a/src/cst.rs
+++ b/src/cst.rs
@@ -233,7 +233,8 @@ pub enum Expr {
     Index {
         collection_span: Span,
         collection: Box<Expr>,
-        index: Box<SpanPrefixedExpr>,
+        index_span: Span,
+        index: Box<Prefixed<Expr>>,
     },
 
     /// A unary operator.

--- a/src/cst.rs
+++ b/src/cst.rs
@@ -231,6 +231,10 @@ pub enum Expr {
 
     /// Index into a collection with `[]`.
     Index {
+        /// The opening bracket.
+        open: Span,
+        /// The closing bracket.
+        close: Span,
         collection_span: Span,
         collection: Box<Expr>,
         index_span: Span,

--- a/src/cst.rs
+++ b/src/cst.rs
@@ -229,6 +229,13 @@ pub enum Expr {
         args: Box<[SpanPrefixedExpr]>,
     },
 
+    /// Index into a collection with `[]`.
+    Index {
+        collection_span: Span,
+        collection: Box<Expr>,
+        index: Box<SpanPrefixedExpr>,
+    },
+
     /// A unary operator.
     UnOp {
         op: UnOp,

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -381,11 +381,15 @@ impl<'a> Evaluator<'a> {
                     .with_note(collection_span, "This is a dict.")
                     .err();
             }
-            _ => {
-                // TODO: Include the value itself in the error message.
+            not_list => {
+                let note = concat! {
+                    "Expected a list, but found: "
+                    format_rcl(not_list).into_owned()
+                    "."
+                };
                 return open_span
                     .error("Indexing is not supported here.")
-                    .with_note(collection_span, "This value is not a list.")
+                    .with_note(collection_span, note)
                     .err();
             }
         };

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -290,6 +290,18 @@ impl<'a> Evaluator<'a> {
                 }
             }
 
+            Expr::Index {
+                collection_span,
+                collection: collection_expr,
+                index: index_expr,
+                index_span,
+                ..
+            } => {
+                let collection = self.eval_expr(env, collection_expr)?;
+                let index = self.eval_expr(env, index_expr)?;
+                self.eval_index(collection, *collection_span, index, *index_span)
+            }
+
             Expr::Lam(_args, _body) => unimplemented!("TODO: Define lambdas."),
 
             Expr::UnOp {
@@ -343,6 +355,16 @@ impl<'a> Evaluator<'a> {
         }
 
         Ok(Rc::new(Value::String(result.into())))
+    }
+
+    fn eval_index(
+        &mut self,
+        _collection: Rc<Value>,
+        _collection_span: Span,
+        _index: Rc<Value>,
+        _index_span: Span,
+    ) -> Result<Rc<Value>> {
+        unimplemented!("TODO: Implement indexing.");
     }
 
     fn eval_unop(&mut self, op: UnOp, op_span: Span, v: Rc<Value>) -> Result<Rc<Value>> {

--- a/src/fmt_cst.rs
+++ b/src/fmt_cst.rs
@@ -370,7 +370,7 @@ impl<'a> Formatter<'a> {
                     group! {
                         "["
                         Doc::SoftBreak
-                        indent! { self.prefixed_expr(&index.as_ref().1) }
+                        indent! { self.prefixed_expr(index) }
                         Doc::SoftBreak
                         "]"
                     }

--- a/src/fmt_cst.rs
+++ b/src/fmt_cst.rs
@@ -362,6 +362,21 @@ impl<'a> Formatter<'a> {
                 }
             }
 
+            Expr::Index {
+                collection, index, ..
+            } => {
+                concat! {
+                    self.expr(collection)
+                    group! {
+                        "["
+                        Doc::SoftBreak
+                        indent! { self.prefixed_expr(&index.as_ref().1) }
+                        Doc::SoftBreak
+                        "]"
+                    }
+                }
+            }
+
             Expr::UnOp { op_span, body, .. } => {
                 concat! {
                     self.span(*op_span)

--- a/src/grammar.y
+++ b/src/grammar.y
@@ -52,6 +52,7 @@ expr_binop: expr_not_op | expr_not_op BINOP expr_binop;
 expr_not_op
   : expr_term
   | expr_not_op '(' call_args ')'
+  | expr_not_op '[' expr ']'
   | expr_not_op '.' IDENT
   ;
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -618,6 +618,18 @@ impl<'a> Parser<'a> {
                         function: Box::new(result),
                     };
                 }
+                Some(Token::LBracket) => {
+                    let result_span = before.until(self.peek_span());
+                    let _open = self.push_bracket()?;
+                    let (index_span, index) = self.parse_prefixed_expr()?;
+                    let _close = self.pop_bracket()?;
+                    result = Expr::Index {
+                        collection_span: result_span,
+                        collection: Box::new(result),
+                        index_span,
+                        index: Box::new(index),
+                    };
+                }
                 Some(Token::Dot) => {
                     self.consume();
                     self.skip_non_code()?;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -620,10 +620,12 @@ impl<'a> Parser<'a> {
                 }
                 Some(Token::LBracket) => {
                     let result_span = before.until(self.peek_span());
-                    let _open = self.push_bracket()?;
+                    let open = self.push_bracket()?;
                     let (index_span, index) = self.parse_prefixed_expr()?;
-                    let _close = self.pop_bracket()?;
+                    let close = self.pop_bracket()?;
                     result = Expr::Index {
+                        open,
+                        close,
                         collection_span: result_span,
                         collection: Box::new(result),
                         index_span,


### PR DESCRIPTION
This adds `collection[index]` syntax for list, string, and dict indexing.

To do:

* [x] Add documentation.
* [x] Ensure test coverage.
* [ ] Add support for binary minus (subtract). → Follow up in new pull request.
* [ ] Implement indexing into strings. → Follow up in new pull request.
* [ ] Implement indexing into dicts. → Follow up in new pull request.
