### PR TITLE
Add methods for string splitting, integer parsing, and folds

### DIFF
--- a/docs/stdlib.md
+++ b/docs/stdlib.md
@@ -4,6 +4,24 @@ The <abbr>RCL</abbr> standard library is a dict of functions that is in scope by
 default under the name `std`. Most of the built-in functionality is not in this
 `std` dict, but in methods on the builtin types. See the next chapters for those.
 
+## range
+
+    std.range: (lower: Int, upper: Int) -> List[Int]
+
+Return the range of integers `lower` through `upper`. The lower bound is
+inclusive and the upper bound is exclusive. When the lower bound is greater
+than the upper bound, `range` returns an empty list.
+
+```rcl
+std.range(3, 7)
+// Evaluates to:
+[3, 4, 5, 6]
+
+std.range(7, 3)
+// Evaluates to:
+[]
+```
+
 ## read_file_utf8
 
     std.read_file_utf8: (path: String) -> String

--- a/docs/type_list.md
+++ b/docs/type_list.md
@@ -14,6 +14,25 @@ Return whether the list contains a given element. For example:
 [true, false]
 ```
 
+## fold
+
+    List.fold: (self: List[T], seed: U, reduce: (U, T) -> U) -> U
+
+Left-fold the function `reduce` over the list, with `seed` as the initial
+accumulator value.
+
+```rcl
+[2, 3, 5, 7, 11].fold(
+  { min = 99, max = 0 },
+  (acc, x) => {
+    min = if acc.min < x then acc.min else x,
+    max = if acc.max > x then acc.max else x,
+  },
+)
+// Evaluates to:
+{ max = 11, min = 11 }
+```
+
 ## group_by
 
     List.group_by: (self: List[T], get_key: T -> U) -> Dict[U, List[T]]

--- a/docs/type_list.md
+++ b/docs/type_list.md
@@ -102,3 +102,15 @@ Return the number of elements in the list. For example:
 // Evaluates to 3.
 [1, 2, 3].len()
 ```
+
+## reverse
+
+    List.reverse (self: List[T]) -> List[T]
+
+Return the list in reverse.
+
+```rcl
+[1, 2, 3].reverse()
+// Evaluates to:
+[3, 2, 1]
+```

--- a/docs/type_list.md
+++ b/docs/type_list.md
@@ -30,7 +30,7 @@ accumulator value.
   },
 )
 // Evaluates to:
-{ max = 11, min = 11 }
+{ max = 11, min = 2 }
 ```
 
 ## group_by
@@ -105,7 +105,7 @@ Return the number of elements in the list. For example:
 
 ## reverse
 
-    List.reverse (self: List[T]) -> List[T]
+    List.reverse: (self: List[T]) -> List[T]
 
 Return the list in reverse.
 

--- a/docs/type_string.md
+++ b/docs/type_string.md
@@ -13,3 +13,50 @@ For example:
 // Evaluates to [7, 2, 10].
 [for s in ["example", "ü", "🕴︎︎"]: s.len()]
 ```
+
+## split
+
+    String.split: (self: String, separator: String) -> List[String]
+
+Split the string on all occurrences of the separator. If the separator occurs
+multiple times in a row, or at the start or end of the string, this produces
+empty strings in the result.
+
+```rcl
+"Leon, Roy, Rachael".split(", ")
+// Evaluates to:
+["Leon", "Roy", "Rachael"]
+
+"|Kowalski||Batty||Tyrell|".split("|")
+// Evaluates to:
+["", "Kowalski", "", "Batty", "", "Tyrell", ""]
+```
+
+## split_lines
+
+    String.split_lines: (self: String) -> List[String]
+
+Split the string on line endings `\n` and `\r\n`. The line endings themselves
+are not included in the result. The final line ending is optional.
+
+```rcl
+"Leon\nRoy\nRachael\n".split_lines()
+// Evaluates to:
+["Leon", "Roy", "Rachael"]
+
+"Kowalski\r\nBatty\rTyrell".split_lines()
+// Evaluates to:
+["Kowalski", "Batty\rTyrell"]
+```
+
+## parse_int
+
+    String.parse_int: (self: String) -> Int
+
+Parse the string as a signed integer in base 10. If the input is not an integer,
+evaluation aborts with an error.
+
+```rcl
+// Evaluates to -42.
+"-42".parse_int()
+```

--- a/etc/pygments/rcl.py
+++ b/etc/pygments/rcl.py
@@ -59,10 +59,15 @@ _root_base = [
         words(
             (
                 "contains",
+                "fold",
                 "get",
                 "group_by",
                 "key_by",
                 "len",
+                "parse_int",
+                "reverse",
+                "split",
+                "split_lines",
                 "std",
             ),
             suffix=r"\b",

--- a/etc/rcl.vim/syntax/rcl.vim
+++ b/etc/rcl.vim/syntax/rcl.vim
@@ -44,7 +44,7 @@ syn region  rclFormatTriple  start='f"""' end='"""' skip='\\"\|\\{' contains=rcl
 
 " See also https://vi.stackexchange.com/questions/5966/ for why the `contains`
 " needs to end in `[]`.
-syn keyword rclBuiltin contains[] get group_by key_by len std
+syn keyword rclBuiltin contains[] fold get group_by key_by len parse_int reverse split split_lines std
 
 syn cluster rclString contains=rclStringDouble,rclStringTriple,rclFormatDouble,rclFormatTriple
 highlight link rclStringDouble rclString

--- a/fuzz/dictionary.txt
+++ b/fuzz/dictionary.txt
@@ -47,8 +47,14 @@
 
 # Builtin methods.
 "contains"
+"fold"
 "get"
 "group_by"
 "key_by"
 "len"
+"parse_int"
+"reverse"
+"split"
+"split_lines"
+"std.range"
 "std.read_file_utf8"

--- a/golden/error/call_stack_context_function.test
+++ b/golden/error/call_stack_context_function.test
@@ -1,0 +1,23 @@
+// The function std.range is not a valid key selector function, but it does have
+// a name, so it gets mentioned in the error context.
+let f = std.range;
+[1, 2, 3].group_by(f)
+
+# output:
+stdin:4:20
+  ╷
+4 │ [1, 2, 3].group_by(f)
+  ╵                    ^
+Error: Missing argument 'upper'. 'std.range' takes 2 arguments, but got 1.
+
+stdin:4:20
+  ╷
+4 │ [1, 2, 3].group_by(f)
+  ╵                    ^
+In call to key selector from 'List.group_by', function 'std.range'.
+
+stdin:4:19
+  ╷
+4 │ [1, 2, 3].group_by(f)
+  ╵                   ^
+In call to method 'List.group_by'.

--- a/golden/error/call_stack_context_method.test
+++ b/golden/error/call_stack_context_method.test
@@ -1,0 +1,23 @@
+// The method String.len is not a valid key selector function, but it does have
+// a name, so it gets mentioned in the error context.
+let f = "ABC".len;
+[1, 2, 3].group_by(f)
+
+# output:
+stdin:4:20
+  ╷
+4 │ [1, 2, 3].group_by(f)
+  ╵                    ^
+Error: Unexpected argument. 'String.len' takes 0 arguments, but got 1.
+
+stdin:4:20
+  ╷
+4 │ [1, 2, 3].group_by(f)
+  ╵                    ^
+In call to key selector from 'List.group_by', method 'String.len'.
+
+stdin:4:19
+  ╷
+4 │ [1, 2, 3].group_by(f)
+  ╵                   ^
+In call to method 'List.group_by'.

--- a/golden/error/runtime_call_arity_contains.test
+++ b/golden/error/runtime_call_arity_contains.test
@@ -6,3 +6,9 @@ stdin:1:26
 1 │ {"k": "v"}.contains("k", "unexpected argument")
   ╵                          ^~~~~~~~~~~~~~~~~~~~~
 Error: Unexpected argument. 'Dict.contains' takes 1 argument, but got 2.
+
+stdin:1:20
+  ╷
+1 │ {"k": "v"}.contains("k", "unexpected argument")
+  ╵                    ^
+In call to method 'Dict.contains'.

--- a/golden/error/runtime_call_arity_dict_get_too_few.test
+++ b/golden/error/runtime_call_arity_dict_get_too_few.test
@@ -6,3 +6,9 @@ stdin:1:13
 1 │ {}.get("key")
   ╵             ^
 Error: Missing argument 'default'. 'Dict.get' takes 2 arguments, but got 1.
+
+stdin:1:7
+  ╷
+1 │ {}.get("key")
+  ╵       ^
+In call to method 'Dict.get'.

--- a/golden/error/runtime_call_arity_dict_get_too_many.test
+++ b/golden/error/runtime_call_arity_dict_get_too_many.test
@@ -6,3 +6,9 @@ stdin:1:26
 1 │ {}.get("key", "default", "unexpected")
   ╵                          ^~~~~~~~~~~~
 Error: Unexpected argument. 'Dict.get' takes 2 arguments, but got 3.
+
+stdin:1:7
+  ╷
+1 │ {}.get("key", "default", "unexpected")
+  ╵       ^
+In call to method 'Dict.get'.

--- a/golden/error/runtime_call_arity_lambda1_too_few.test
+++ b/golden/error/runtime_call_arity_lambda1_too_few.test
@@ -8,14 +8,14 @@ stdin:2:3
   ╵   ^
 Error: Missing argument '_'. The function takes 1 argument, but got 0.
 
-stdin:2:2
-  ╷
-2 │ f()
-  ╵  ^
-In call to function.
-
 stdin:1:11
   ╷
 1 │ let f = _ => 42;
   ╵           ^~
 Note: Function defined here.
+
+stdin:2:2
+  ╷
+2 │ f()
+  ╵  ^
+In call to function.

--- a/golden/error/runtime_call_arity_lambda1_too_few.test
+++ b/golden/error/runtime_call_arity_lambda1_too_few.test
@@ -8,6 +8,12 @@ stdin:2:3
   ╵   ^
 Error: Missing argument '_'. The function takes 1 argument, but got 0.
 
+stdin:2:2
+  ╷
+2 │ f()
+  ╵  ^
+In call to function.
+
 stdin:1:11
   ╷
 1 │ let f = _ => 42;

--- a/golden/error/runtime_call_arity_lambda1_too_many.test
+++ b/golden/error/runtime_call_arity_lambda1_too_many.test
@@ -8,14 +8,14 @@ stdin:2:10
   ╵          ^~~~~~
 Error: Unexpected argument. The function takes 1 argument, but got 2.
 
-stdin:2:2
-  ╷
-2 │ f("too", "many")
-  ╵  ^
-In call to function.
-
 stdin:1:11
   ╷
 1 │ let f = _ => 42;
   ╵           ^~
 Note: Function defined here.
+
+stdin:2:2
+  ╷
+2 │ f("too", "many")
+  ╵  ^
+In call to function.

--- a/golden/error/runtime_call_arity_lambda1_too_many.test
+++ b/golden/error/runtime_call_arity_lambda1_too_many.test
@@ -8,6 +8,12 @@ stdin:2:10
   ╵          ^~~~~~
 Error: Unexpected argument. The function takes 1 argument, but got 2.
 
+stdin:2:2
+  ╷
+2 │ f("too", "many")
+  ╵  ^
+In call to function.
+
 stdin:1:11
   ╷
 1 │ let f = _ => 42;

--- a/golden/error/runtime_call_arity_lambda2_too_few.test
+++ b/golden/error/runtime_call_arity_lambda2_too_few.test
@@ -8,14 +8,14 @@ stdin:2:12
   ╵            ^
 Error: Missing argument 'y'. The function takes 2 arguments, but got 1.
 
-stdin:2:2
-  ╷
-2 │ f("too few")
-  ╵  ^
-In call to function.
-
 stdin:1:16
   ╷
 1 │ let f = (x, y) => x;
   ╵                ^~
 Note: Function defined here.
+
+stdin:2:2
+  ╷
+2 │ f("too few")
+  ╵  ^
+In call to function.

--- a/golden/error/runtime_call_arity_lambda2_too_few.test
+++ b/golden/error/runtime_call_arity_lambda2_too_few.test
@@ -8,6 +8,12 @@ stdin:2:12
   ╵            ^
 Error: Missing argument 'y'. The function takes 2 arguments, but got 1.
 
+stdin:2:2
+  ╷
+2 │ f("too few")
+  ╵  ^
+In call to function.
+
 stdin:1:16
   ╷
 1 │ let f = (x, y) => x;

--- a/golden/error/runtime_call_arity_lambda2_too_many.test
+++ b/golden/error/runtime_call_arity_lambda2_too_many.test
@@ -8,6 +8,12 @@ stdin:2:17
   ╵                 ^~~~~~
 Error: Unexpected argument. The function takes 2 arguments, but got 3.
 
+stdin:2:2
+  ╷
+2 │ f("one", "too", "many")
+  ╵  ^
+In call to function.
+
 stdin:1:16
   ╷
 1 │ let f = (x, y) => x;

--- a/golden/error/runtime_call_arity_lambda2_too_many.test
+++ b/golden/error/runtime_call_arity_lambda2_too_many.test
@@ -8,14 +8,14 @@ stdin:2:17
   ╵                 ^~~~~~
 Error: Unexpected argument. The function takes 2 arguments, but got 3.
 
-stdin:2:2
-  ╷
-2 │ f("one", "too", "many")
-  ╵  ^
-In call to function.
-
 stdin:1:16
   ╷
 1 │ let f = (x, y) => x;
   ╵                ^~
 Note: Function defined here.
+
+stdin:2:2
+  ╷
+2 │ f("one", "too", "many")
+  ╵  ^
+In call to function.

--- a/golden/error/runtime_not_fn_1.test
+++ b/golden/error/runtime_not_fn_1.test
@@ -6,3 +6,9 @@ stdin:1:1
 1 │ "frobnicator"()
   ╵ ^~~~~~~~~~~~~
 Error: This is not a function, it cannot be called.
+
+stdin:1:14
+  ╷
+1 │ "frobnicator"()
+  ╵              ^
+In call.

--- a/golden/error/runtime_not_fn_2.test
+++ b/golden/error/runtime_not_fn_2.test
@@ -7,3 +7,9 @@ stdin:2:1
 2 │ person.name()
   ╵ ^~~~~~~~~~~
 Error: This is not a function, it cannot be called.
+
+stdin:2:12
+  ╷
+2 │ person.name()
+  ╵            ^
+In call.

--- a/golden/error/runtime_not_fn_3.test
+++ b/golden/error/runtime_not_fn_3.test
@@ -6,3 +6,9 @@ stdin:1:1
 1 │ "frobnicator".len()(42)
   ╵ ^~~~~~~~~~~~~~~~~~~
 Error: This is not a function, it cannot be called.
+
+stdin:1:20
+  ╷
+1 │ "frobnicator".len()(42)
+  ╵                    ^
+In call.

--- a/golden/error/runtime_std_range_too_big.test
+++ b/golden/error/runtime_std_range_too_big.test
@@ -9,3 +9,9 @@ stdin:3:34
 3 │ let err = std.range(10, 1_000_011);
   ╵                                  ^
 Error: Range 10..1000011 exceeds the maximum length of 1000000. The list would require too much memory.
+
+stdin:3:20
+  ╷
+3 │ let err = std.range(10, 1_000_011);
+  ╵                    ^
+In call to function 'std.range'.

--- a/golden/error/runtime_std_range_too_big.test
+++ b/golden/error/runtime_std_range_too_big.test
@@ -1,0 +1,11 @@
+// We don't test the greatest range that does not fail, to keep the tests fast.
+let still_ok = std.range(0, 100);
+let err = std.range(10, 1_000_011);
+0
+
+# output:
+stdin:3:34
+  ╷
+3 │ let err = std.range(10, 1_000_011);
+  ╵                                  ^
+Error: Range 10..1000011 exceeds the maximum length of 1000000. The list would require too much memory.

--- a/golden/error/runtime_unknown_field_list.test
+++ b/golden/error/runtime_unknown_field_list.test
@@ -12,3 +12,14 @@ stdin:7:19
 7 │ turbo_encabulator.is_prefabulated
   ╵                   ^~~~~~~~~~~~~~~
 Error: Unknown field.
+
+stdin:7:1
+  ╷
+7 │ turbo_encabulator.is_prefabulated
+  ╵ ^~~~~~~~~~~~~~~~~
+Note: On value: [
+  "differential girdlespacing",
+  "hydrocoptic marzlevanes",
+  "pentametric fan",
+  "spurving bearings",
+]

--- a/golden/error/runtime_unknown_field_record.test
+++ b/golden/error/runtime_unknown_field_record.test
@@ -10,3 +10,9 @@ stdin:5:8
 5 │ widget.is_prefabulated
   ╵        ^~~~~~~~~~~~~~~
 Error: Unknown field.
+
+stdin:5:1
+  ╷
+5 │ widget.is_prefabulated
+  ╵ ^~~~~~
+Note: On value: { marzlevanes = ["hydrocoptic"], name = "Turbo encabulator" }

--- a/golden/error/runtime_unknown_field_string.test
+++ b/golden/error/runtime_unknown_field_string.test
@@ -6,3 +6,9 @@ stdin:1:21
 1 │ "turbo encabulator".is_prefabulated
   ╵                     ^~~~~~~~~~~~~~~
 Error: Unknown field.
+
+stdin:1:1
+  ╷
+1 │ "turbo encabulator".is_prefabulated
+  ╵ ^~~~~~~~~~~~~~~~~~~
+Note: On value: "turbo encabulator"

--- a/golden/error/std_list_fold_error_in_reduce.test
+++ b/golden/error/std_list_fold_error_in_reduce.test
@@ -2,11 +2,23 @@
 [1, 2].fold(0, (acc, x) => acc + x.len())
 
 # output:
+stdin:2:36
+  ╷
+2 │ [1, 2].fold(0, (acc, x) => acc + x.len())
+  ╵                                    ^~~
+Error: Unknown field.
+
 stdin:2:16
   ╷
 2 │ [1, 2].fold(0, (acc, x) => acc + x.len())
   ╵                ^~~~~~~~~~~~~~~~~~~~~~~~~
-Error: In call to reduce in 'List.fold': Unknown field.
+In call to reduce function from 'List.fold'.
+
+stdin:2:12
+  ╷
+2 │ [1, 2].fold(0, (acc, x) => acc + x.len())
+  ╵            ^
+In call to method 'List.fold'.
 
 stdin:2:34
   ╷

--- a/golden/error/std_list_fold_error_in_reduce.test
+++ b/golden/error/std_list_fold_error_in_reduce.test
@@ -8,6 +8,12 @@ stdin:2:36
   ╵                                    ^~~
 Error: Unknown field.
 
+stdin:2:34
+  ╷
+2 │ [1, 2].fold(0, (acc, x) => acc + x.len())
+  ╵                                  ^
+Note: On value: 1
+
 stdin:2:16
   ╷
 2 │ [1, 2].fold(0, (acc, x) => acc + x.len())
@@ -19,9 +25,3 @@ stdin:2:12
 2 │ [1, 2].fold(0, (acc, x) => acc + x.len())
   ╵            ^
 In call to method 'List.fold'.
-
-stdin:2:34
-  ╷
-2 │ [1, 2].fold(0, (acc, x) => acc + x.len())
-  ╵                                  ^
-Note: On value: 1

--- a/golden/error/std_list_fold_error_in_reduce.test
+++ b/golden/error/std_list_fold_error_in_reduce.test
@@ -1,0 +1,15 @@
+// We can't call .len() on an int, this causes a type error in the reduce function.
+[1, 2].fold(0, (acc, x) => acc + x.len())
+
+# output:
+stdin:2:16
+  ╷
+2 │ [1, 2].fold(0, (acc, x) => acc + x.len())
+  ╵                ^~~~~~~~~~~~~~~~~~~~~~~~~
+Error: In call to reduce in 'List.fold': Unknown field.
+
+stdin:2:34
+  ╷
+2 │ [1, 2].fold(0, (acc, x) => acc + x.len())
+  ╵                                  ^
+Note: On value: 1

--- a/golden/error/std_list_fold_not_callable.test
+++ b/golden/error/std_list_fold_not_callable.test
@@ -5,4 +5,16 @@ stdin:1:13
   ╷
 1 │ [1].fold(0, "not callable")
   ╵             ^~~~~~~~~~~~~~
-Error: In call to reduce in 'List.fold': This is not a function, it cannot be called.
+Error: This is not a function, it cannot be called.
+
+stdin:1:13
+  ╷
+1 │ [1].fold(0, "not callable")
+  ╵             ^~~~~~~~~~~~~~
+In call to reduce function from 'List.fold'.
+
+stdin:1:9
+  ╷
+1 │ [1].fold(0, "not callable")
+  ╵         ^
+In call to method 'List.fold'.

--- a/golden/error/std_list_fold_not_callable.test
+++ b/golden/error/std_list_fold_not_callable.test
@@ -1,0 +1,8 @@
+[1].fold(0, "not callable")
+
+# output:
+stdin:1:13
+  ╷
+1 │ [1].fold(0, "not callable")
+  ╵             ^~~~~~~~~~~~~~
+Error: In call to reduce in 'List.fold': This is not a function, it cannot be called.

--- a/golden/error/std_list_group_by_arity_too_large.test
+++ b/golden/error/std_list_group_by_arity_too_large.test
@@ -7,6 +7,12 @@ stdin:1:20
   ╵                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Error: Missing argument 'v'. The function takes 2 arguments, but got 1.
 
+stdin:1:27
+  ╷
+1 │ [1, 2, 3].group_by((k, v) => "this get_key has too many arguments")
+  ╵                           ^~
+Note: Function defined here.
+
 stdin:1:20
   ╷
 1 │ [1, 2, 3].group_by((k, v) => "this get_key has too many arguments")
@@ -18,9 +24,3 @@ stdin:1:19
 1 │ [1, 2, 3].group_by((k, v) => "this get_key has too many arguments")
   ╵                   ^
 In call to method 'List.group_by'.
-
-stdin:1:27
-  ╷
-1 │ [1, 2, 3].group_by((k, v) => "this get_key has too many arguments")
-  ╵                           ^~
-Note: Function defined here.

--- a/golden/error/std_list_group_by_arity_too_large.test
+++ b/golden/error/std_list_group_by_arity_too_large.test
@@ -5,7 +5,19 @@ stdin:1:20
   ╷
 1 │ [1, 2, 3].group_by((k, v) => "this get_key has too many arguments")
   ╵                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-Error: In call to key selector in 'List.group_by': Missing argument 'v'. The function takes 2 arguments, but got 1.
+Error: Missing argument 'v'. The function takes 2 arguments, but got 1.
+
+stdin:1:20
+  ╷
+1 │ [1, 2, 3].group_by((k, v) => "this get_key has too many arguments")
+  ╵                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+In call to key selector from 'List.group_by'.
+
+stdin:1:19
+  ╷
+1 │ [1, 2, 3].group_by((k, v) => "this get_key has too many arguments")
+  ╵                   ^
+In call to method 'List.group_by'.
 
 stdin:1:27
   ╷

--- a/golden/error/std_list_group_by_arity_too_small.test
+++ b/golden/error/std_list_group_by_arity_too_small.test
@@ -7,6 +7,12 @@ stdin:1:20
   ╵                    ^
 Error: Unexpected argument. The function takes 0 arguments, but got 1.
 
+stdin:1:23
+  ╷
+1 │ [1, 2, 3].group_by(() => "this get_key has too few arguments")
+  ╵                       ^~
+Note: Function defined here.
+
 stdin:1:20
   ╷
 1 │ [1, 2, 3].group_by(() => "this get_key has too few arguments")
@@ -18,9 +24,3 @@ stdin:1:19
 1 │ [1, 2, 3].group_by(() => "this get_key has too few arguments")
   ╵                   ^
 In call to method 'List.group_by'.
-
-stdin:1:23
-  ╷
-1 │ [1, 2, 3].group_by(() => "this get_key has too few arguments")
-  ╵                       ^~
-Note: Function defined here.

--- a/golden/error/std_list_group_by_arity_too_small.test
+++ b/golden/error/std_list_group_by_arity_too_small.test
@@ -4,8 +4,20 @@
 stdin:1:20
   ╷
 1 │ [1, 2, 3].group_by(() => "this get_key has too few arguments")
+  ╵                    ^
+Error: Unexpected argument. The function takes 0 arguments, but got 1.
+
+stdin:1:20
+  ╷
+1 │ [1, 2, 3].group_by(() => "this get_key has too few arguments")
   ╵                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-Error: In call to key selector in 'List.group_by': Unexpected argument. The function takes 0 arguments, but got 1.
+In call to key selector from 'List.group_by'.
+
+stdin:1:19
+  ╷
+1 │ [1, 2, 3].group_by(() => "this get_key has too few arguments")
+  ╵                   ^
+In call to method 'List.group_by'.
 
 stdin:1:23
   ╷

--- a/golden/error/std_list_group_by_not_callable.test
+++ b/golden/error/std_list_group_by_not_callable.test
@@ -5,4 +5,16 @@ stdin:1:20
   ╷
 1 │ [1, 2, 3].group_by("not a function")
   ╵                    ^~~~~~~~~~~~~~~~
-Error: In call to key selector in 'List.group_by': This is not a function, it cannot be called.
+Error: This is not a function, it cannot be called.
+
+stdin:1:20
+  ╷
+1 │ [1, 2, 3].group_by("not a function")
+  ╵                    ^~~~~~~~~~~~~~~~
+In call to key selector from 'List.group_by'.
+
+stdin:1:19
+  ╷
+1 │ [1, 2, 3].group_by("not a function")
+  ╵                   ^
+In call to method 'List.group_by'.

--- a/golden/error/std_list_key_by_not_unique.test
+++ b/golden/error/std_list_key_by_not_unique.test
@@ -16,3 +16,9 @@ Error: The key 6 is not unique. The following values use this key:
   { generation = 6, name = "Roy Batty" }
   { generation = 6, name = "Pris Stratton" }
   { generation = 6, name = "Zhora Salome" }
+
+stdin:7:18
+  ╷
+7 │ replicants.key_by(r => r.generation)
+  ╵                  ^
+In call to method 'List.key_by'.

--- a/golden/error/std_range_not_int_0.test
+++ b/golden/error/std_range_not_int_0.test
@@ -6,3 +6,9 @@ stdin:1:11
 1 │ std.range("not int", 10)
   ╵           ^~~~~~~~~
 Error: Expected an Int here, but got a different type.
+
+stdin:1:10
+  ╷
+1 │ std.range("not int", 10)
+  ╵          ^
+In call to function 'std.range'.

--- a/golden/error/std_range_not_int_0.test
+++ b/golden/error/std_range_not_int_0.test
@@ -1,0 +1,8 @@
+std.range("not int", 10)
+
+# output:
+stdin:1:11
+  ╷
+1 │ std.range("not int", 10)
+  ╵           ^~~~~~~~~
+Error: Expected an Int here, but got a different type.

--- a/golden/error/std_range_not_int_1.test
+++ b/golden/error/std_range_not_int_1.test
@@ -1,0 +1,8 @@
+std.range(0, "not int")
+
+# output:
+stdin:1:14
+  ╷
+1 │ std.range(0, "not int")
+  ╵              ^~~~~~~~~
+Error: Expected an Int here, but got a different type.

--- a/golden/error/std_range_not_int_1.test
+++ b/golden/error/std_range_not_int_1.test
@@ -6,3 +6,9 @@ stdin:1:14
 1 │ std.range(0, "not int")
   ╵              ^~~~~~~~~
 Error: Expected an Int here, but got a different type.
+
+stdin:1:10
+  ╷
+1 │ std.range(0, "not int")
+  ╵          ^
+In call to function 'std.range'.

--- a/golden/error/std_read_file_utf8_arity_too_few.test
+++ b/golden/error/std_read_file_utf8_arity_too_few.test
@@ -6,3 +6,9 @@ stdin:1:20
 1 │ std.read_file_utf8()
   ╵                    ^
 Error: Missing argument 'path'. 'std.read_file_utf8' takes 1 argument, but got 0.
+
+stdin:1:19
+  ╷
+1 │ std.read_file_utf8()
+  ╵                   ^
+In call to function 'std.read_file_utf8'.

--- a/golden/error/std_read_file_utf8_arity_too_many.test
+++ b/golden/error/std_read_file_utf8_arity_too_many.test
@@ -6,3 +6,9 @@ stdin:1:25
 1 │ std.read_file_utf8("a", "b")
   ╵                         ^~~
 Error: Unexpected argument. 'std.read_file_utf8' takes 1 argument, but got 2.
+
+stdin:1:19
+  ╷
+1 │ std.read_file_utf8("a", "b")
+  ╵                   ^
+In call to function 'std.read_file_utf8'.

--- a/golden/error/std_read_file_utf8_not_found.test
+++ b/golden/error/std_read_file_utf8_not_found.test
@@ -6,3 +6,9 @@ stdin:1:20
 1 │ std.read_file_utf8("non_existing_path.txt")
   ╵                    ^~~~~~~~~~~~~~~~~~~~~~~
 Error: Failed to access path '/WORKDIR/error/non_existing_path.txt': No such file or directory (os error 2)
+
+stdin:1:19
+  ╷
+1 │ std.read_file_utf8("non_existing_path.txt")
+  ╵                   ^
+In call to function 'std.read_file_utf8'.

--- a/golden/error/std_read_file_utf8_not_string.test
+++ b/golden/error/std_read_file_utf8_not_string.test
@@ -6,3 +6,9 @@ stdin:1:20
 1 │ std.read_file_utf8(false)
   ╵                    ^~~~~
 Error: Expected a String here, but got a different type.
+
+stdin:1:19
+  ╷
+1 │ std.read_file_utf8(false)
+  ╵                   ^
+In call to function 'std.read_file_utf8'.

--- a/golden/error/std_set_key_by_not_unique.test
+++ b/golden/error/std_set_key_by_not_unique.test
@@ -16,3 +16,9 @@ Error: The key 6 is not unique. The following values use this key:
   { generation = 6, name = "Pris Stratton" }
   { generation = 6, name = "Roy Batty" }
   { generation = 6, name = "Zhora Salome" }
+
+stdin:7:18
+  ╷
+7 │ replicants.key_by(r => r.generation)
+  ╵                  ^
+In call to method 'Set.key_by'.

--- a/golden/error/std_string_parse_int.test
+++ b/golden/error/std_string_parse_int.test
@@ -1,0 +1,11 @@
+// TODO: Should the error point at the receiver? It's nice sometimes, but it
+// may also be confused for a syntax error in other occasions, we should at
+// least point at the call paren as well.
+"0xbadbeef".parse_int()
+
+# output:
+stdin:4:1
+  ╷
+4 │ "0xbadbeef".parse_int()
+  ╵ ^~~~~~~~~~~
+Error: Failed to parse as integer: "0xbadbeef"

--- a/golden/error/std_string_parse_int.test
+++ b/golden/error/std_string_parse_int.test
@@ -1,11 +1,14 @@
-// TODO: Should the error point at the receiver? It's nice sometimes, but it
-// may also be confused for a syntax error in other occasions, we should at
-// least point at the call paren as well.
 "0xbadbeef".parse_int()
 
 # output:
-stdin:4:1
+stdin:1:1
   ╷
-4 │ "0xbadbeef".parse_int()
+1 │ "0xbadbeef".parse_int()
   ╵ ^~~~~~~~~~~
 Error: Failed to parse as integer: "0xbadbeef"
+
+stdin:1:22
+  ╷
+1 │ "0xbadbeef".parse_int()
+  ╵                      ^
+In call to method 'String.parse_int'.

--- a/golden/error/std_string_split_lines.test
+++ b/golden/error/std_string_split_lines.test
@@ -1,0 +1,12 @@
+{
+  a =
+    """
+    Line 1
+    Line 2
+    """.split_lines(),
+  crlf1 = "a\r\nb\r\nc\r\n".split_lines(),
+  crlf2 = "a\r\nb\r\nc".split_lines(),
+}
+
+# output:
+{ a = ["Line 1", "Line 2"], crlf1 = ["a", "b", "c"], crlf2 = ["a", "b", "c"] }

--- a/golden/error/std_string_split_not_string.test
+++ b/golden/error/std_string_split_not_string.test
@@ -1,0 +1,8 @@
+"foo,bar,baz".split(1)
+
+# output:
+stdin:1:21
+  ╷
+1 │ "foo,bar,baz".split(1)
+  ╵                     ^
+Error: Separator must be a string.

--- a/golden/error/std_string_split_not_string.test
+++ b/golden/error/std_string_split_not_string.test
@@ -6,3 +6,9 @@ stdin:1:21
 1 │ "foo,bar,baz".split(1)
   ╵                     ^
 Error: Separator must be a string.
+
+stdin:1:20
+  ╷
+1 │ "foo,bar,baz".split(1)
+  ╵                    ^
+In call to method 'String.split'.

--- a/golden/json/list_reverse.test
+++ b/golden/json/list_reverse.test
@@ -1,0 +1,4 @@
+["a", "b", "c"].reverse()
+
+# output:
+["c", "b", "a"]

--- a/golden/json/std_range.test
+++ b/golden/json/std_range.test
@@ -1,0 +1,7 @@
+{
+  non_empty = std.range(-4, 6),
+  empty = std.range(6, -4),
+}
+
+# output:
+{"empty": [], "non_empty": [-4, -3, -2, -1, 0, 1, 2, 3, 4, 5]}

--- a/golden/rcl/list_fold.test
+++ b/golden/rcl/list_fold.test
@@ -4,8 +4,20 @@
 }
 
 # output:
+stdin:3:56
+  ╷
+3 │   str = ["foo", "bar", "baz"].fold("", (acc, s) => acc + s),
+  ╵                                                        ^
+Error: This operator is not supported for these values.
+
 stdin:3:40
   ╷
 3 │   str = ["foo", "bar", "baz"].fold("", (acc, s) => acc + s),
   ╵                                        ^~~~~~~~~~~~~~~~~~~
-Error: In call to reduce in 'List.fold': This operator is not supported for these values.
+In call to reduce function from 'List.fold'.
+
+stdin:3:35
+  ╷
+3 │   str = ["foo", "bar", "baz"].fold("", (acc, s) => acc + s),
+  ╵                                   ^
+In call to method 'List.fold'.

--- a/golden/rcl/list_fold.test
+++ b/golden/rcl/list_fold.test
@@ -1,0 +1,11 @@
+{
+  int = [2, 3, 5, 8, 11, 13].fold(0, (x, y) => x + y),
+  str = ["foo", "bar", "baz"].fold("", (acc, s) => acc + s),
+}
+
+# output:
+stdin:3:40
+  ╷
+3 │   str = ["foo", "bar", "baz"].fold("", (acc, s) => acc + s),
+  ╵                                        ^~~~~~~~~~~~~~~~~~~
+Error: In call to reduce in 'List.fold': This operator is not supported for these values.

--- a/golden/rcl/string_parse_int.test
+++ b/golden/rcl/string_parse_int.test
@@ -1,0 +1,7 @@
+[
+  "42".parse_int(),
+  "-42".parse_int(),
+]
+
+# output:
+[42, -42]

--- a/golden/rcl/string_split.test
+++ b/golden/rcl/string_split.test
@@ -1,0 +1,19 @@
+{
+  a = "foo, bar, baz".split(", "),
+  b = "|x|y|z".split("|"),
+  c = "x&y&&z&".split("&"),
+  // Splitting on empty string creates a leading and trailing empty string.
+  // I'm not sure how I feel about this, maybe splitting on empty string should
+  // be an error. It's an error in Python at least. But the current behavior is
+  // what Rust's split does, and it comes in handy for leetcoding if you need
+  // the chars. TODO: Add a .chars() method and then disallow empty separator.
+  d = "xyz".split(""),
+}
+
+# output:
+{
+  a = ["foo", "bar", "baz"],
+  b = ["", "x", "y", "z"],
+  c = ["x", "y", "", "z", ""],
+  d = ["", "x", "y", "z", ""],
+}

--- a/ideas/roadmap.md
+++ b/ideas/roadmap.md
@@ -2,50 +2,17 @@
 
 ## Near term
 
-* [WIP] Colored output for json.
- * The ability to turn coloring on or off, respect <https://no-color.org/>.
- * Add assertions.
+ * Accept an expression through `--expr` for `rcl evaluate`.
+ * Add a `--raw` output mode (or maybe `--output raw`) for outputting strings
+   without quotes.
+ * Actually implement the `--in-place` for `rcl fmt`.
+ * Add a `--follow` for `rcl fmt` that follows imports.
+
+## Mid-term
+
+ * Yaml output mode.
+ * Preserve insertion order in dicts and sets, GC'd runtime.
  * Absorb the `highlight` command into `fmt` and make it use the same coloring?
- * Different output modes, RCL in addition to json (so we can preserve sets);
-   possibly yaml output.
- * Preserve insertion order in dicts and sets.
-
-## Method vs. field access
-
-After playing with this for some time, I think I will give in and just use
-different syntax for method calls vs. field access. Field access gets the dot,
-method call gets `->`.
-
-    let x = {
-      len = 100;
-      name = "x";
-      contains = (name) => name == "prop";
-    };
-    // Returns [100, 2]:
-    [x.len, x->len()]
-
-    // Returns [true, false]:
-    [x->contains("name"), x.contains("name")]
-
-    // Returns [false, true]:
-    [x->contains("prop"), x.contains("prop")]
-
-Though it does make me slightly sad, the dot just looks so much friendlier.
-Maybe field access should get the `->` instead?
-
-## Trailing semicolons
-
-Mixing `,` and `;` in the same dict is weird. Also, if I want to allow kwargs,
-the natural separator would be comma rather than semicolon. Maybe just bite the
-bullet?
-
-    let x = {
-      len = 100,
-      name = "x",
-      contains = (name) => name == "prop",
-    };
-
-Doesn't look so bad, I can live with this.
 
 ## Long-term
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -222,13 +222,6 @@ impl Error {
             result.push(body);
         }
 
-        for (call_span, call_frame_message) in self.call_stack {
-            result.push(Doc::HardBreak);
-            result.push(Doc::HardBreak);
-            result.push(highlight_span(inputs, call_span, Markup::Error));
-            result.push(call_frame_message);
-        }
-
         for (note_span, note_message) in self.notes {
             result.push(Doc::HardBreak);
             result.push(Doc::HardBreak);
@@ -244,6 +237,15 @@ impl Error {
             result.push(Doc::from("Help:").with_markup(Markup::Warning));
             result.push(" ".into());
             result.push(help_message);
+        }
+
+        // We print the call stack last, after the help and notes, because the
+        // help and notes refer to the inner error.
+        for (call_span, call_frame_message) in self.call_stack {
+            result.push(Doc::HardBreak);
+            result.push(Doc::HardBreak);
+            result.push(highlight_span(inputs, call_span, Markup::Error));
+            result.push(call_frame_message);
         }
 
         Doc::Concat(result)

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -229,6 +229,7 @@ impl<'a> Evaluator<'a> {
                 let err_unknown_field = field_span.error("Unknown field.");
                 let builtin = match (inner.as_ref(), field_name.as_ref()) {
                     (Value::String(_), "len") => Some(stdlib::STRING_LEN),
+                    (Value::String(_), "split") => Some(stdlib::STRING_SPLIT),
 
                     (Value::Dict(_), "contains") => Some(stdlib::DICT_CONTAINS),
                     (Value::Dict(_), "get") => Some(stdlib::DICT_GET),

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -262,6 +262,7 @@ impl<'a> Evaluator<'a> {
                     (Value::List(_), "group_by") => Some(stdlib::LIST_GROUP_BY),
                     (Value::List(_), "key_by") => Some(stdlib::LIST_KEY_BY),
                     (Value::List(_), "len") => Some(stdlib::LIST_LEN),
+                    (Value::List(_), "reverse") => Some(stdlib::LIST_REVERSE),
 
                     (Value::Set(_), "contains") => Some(stdlib::SET_CONTAINS),
                     (Value::Set(_), "group_by") => Some(stdlib::SET_GROUP_BY),

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -231,6 +231,7 @@ impl<'a> Evaluator<'a> {
                     (Value::String(_), "len") => Some(stdlib::STRING_LEN),
                     (Value::String(_), "split") => Some(stdlib::STRING_SPLIT),
                     (Value::String(_), "split_lines") => Some(stdlib::STRING_SPLIT_LINES),
+                    (Value::String(_), "parse_int") => Some(stdlib::STRING_PARSE_INT),
 
                     (Value::Dict(_), "contains") => Some(stdlib::DICT_CONTAINS),
                     (Value::Dict(_), "get") => Some(stdlib::DICT_GET),

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -258,6 +258,7 @@ impl<'a> Evaluator<'a> {
                     }
 
                     (Value::List(_), "contains") => Some(stdlib::LIST_CONTAINS),
+                    (Value::List(_), "fold") => Some(stdlib::LIST_FOLD),
                     (Value::List(_), "group_by") => Some(stdlib::LIST_GROUP_BY),
                     (Value::List(_), "key_by") => Some(stdlib::LIST_KEY_BY),
                     (Value::List(_), "len") => Some(stdlib::LIST_LEN),

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -279,7 +279,7 @@ impl<'a> Evaluator<'a> {
                         method: b,
                     })),
                     None => {
-                        return field_span
+                        field_span
                             .error("Unknown field.")
                             .with_note(
                                 *inner_span,
@@ -289,7 +289,7 @@ impl<'a> Evaluator<'a> {
                                     "On value: " format_rcl(inner.as_ref()).into_owned()
                                 },
                             )
-                            .err();
+                            .err()
                     }
                 }
             }

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -230,6 +230,7 @@ impl<'a> Evaluator<'a> {
                 let builtin = match (inner.as_ref(), field_name.as_ref()) {
                     (Value::String(_), "len") => Some(stdlib::STRING_LEN),
                     (Value::String(_), "split") => Some(stdlib::STRING_SPLIT),
+                    (Value::String(_), "split_lines") => Some(stdlib::STRING_SPLIT_LINES),
 
                     (Value::Dict(_), "contains") => Some(stdlib::DICT_CONTAINS),
                     (Value::Dict(_), "get") => Some(stdlib::DICT_GET),

--- a/src/highlight.rs
+++ b/src/highlight.rs
@@ -26,7 +26,8 @@ fn get_color(token: &Token, token_bytes: &[u8]) -> &'static str {
         Token::NumBinary | Token::NumHexadecimal | Token::NumDecimal => cyan,
         Token::Ident => match token_bytes {
             // Give the builtins a different color.
-            b"contains" | b"get" | b"group_by" | b"key_by" | b"len" | b"std" => red,
+            b"contains" | b"fold" | b"get" | b"group_by" | b"key_by" | b"len" | b"parse_int"
+            | b"reverse" | b"split" | b"split_lines" | b"std" => red,
             _ => blue,
         },
 

--- a/src/stdlib.rs
+++ b/src/stdlib.rs
@@ -232,3 +232,23 @@ fn builtin_set_key_by(eval: &mut Evaluator, call: MethodCall) -> Result<Rc<Value
     let set = call.receiver.expect_set();
     builtin_key_by_impl(eval, call, "Set.key_by", set)
 }
+
+builtin_method!("String.split", const STRING_SPLIT, builtin_string_split);
+fn builtin_string_split(_eval: &mut Evaluator, call: MethodCall) -> Result<Rc<Value>> {
+    call.call
+        .check_arity_static("String.split", &["separator"])?;
+    let string = call.receiver.expect_string();
+
+    let sep_arg = &call.call.args[0];
+    let sep = match sep_arg.value.as_ref() {
+        Value::String(sep) => sep.as_ref(),
+        _ => return sep_arg.span.error("Separator must be a string.").err(),
+    };
+
+    let result: Vec<Rc<Value>> = string
+        .split(sep)
+        .map(|part| Rc::new(Value::from(part)))
+        .collect();
+
+    Ok(Rc::new(Value::List(result)))
+}

--- a/src/stdlib.rs
+++ b/src/stdlib.rs
@@ -373,3 +373,11 @@ fn builtin_list_fold(eval: &mut Evaluator, call: MethodCall) -> Result<Rc<Value>
 
     Ok(acc)
 }
+
+builtin_method!("List.reverse", const LIST_REVERSE, builtin_list_reverse);
+fn builtin_list_reverse(_eval: &mut Evaluator, call: MethodCall) -> Result<Rc<Value>> {
+    call.call.check_arity_static("List.reverse", &[])?;
+    let list = call.receiver.expect_list();
+    let reversed = list.iter().rev().cloned().collect();
+    Ok(Rc::new(Value::List(reversed)))
+}

--- a/src/stdlib.rs
+++ b/src/stdlib.rs
@@ -252,3 +252,16 @@ fn builtin_string_split(_eval: &mut Evaluator, call: MethodCall) -> Result<Rc<Va
 
     Ok(Rc::new(Value::List(result)))
 }
+
+builtin_method!("String.split_lines", const STRING_SPLIT_LINES, builtin_string_split_lines);
+fn builtin_string_split_lines(_eval: &mut Evaluator, call: MethodCall) -> Result<Rc<Value>> {
+    call.call.check_arity_static("String.split_lines", &[])?;
+    let string = call.receiver.expect_string();
+
+    let result: Vec<Rc<Value>> = string
+        .lines()
+        .map(|part| Rc::new(Value::from(part)))
+        .collect();
+
+    Ok(Rc::new(Value::List(result)))
+}

--- a/src/stdlib.rs
+++ b/src/stdlib.rs
@@ -265,3 +265,20 @@ fn builtin_string_split_lines(_eval: &mut Evaluator, call: MethodCall) -> Result
 
     Ok(Rc::new(Value::List(result)))
 }
+
+builtin_method!("String.parse_int", const STRING_PARSE_INT, builtin_string_parse_int);
+fn builtin_string_parse_int(_eval: &mut Evaluator, call: MethodCall) -> Result<Rc<Value>> {
+    use std::str::FromStr;
+
+    call.call.check_arity_static("String.parse_int", &[])?;
+    let string = call.receiver.expect_string();
+
+    match i64::from_str(string.as_ref()) {
+        Ok(i) => Ok(Rc::new(Value::Int(i))),
+        Err(..) => call
+            .receiver_span
+            .error("Failed to parse as integer:")
+            .with_body(format_rcl(call.receiver).into_owned())
+            .err(),
+    }
+}

--- a/src/stdlib.rs
+++ b/src/stdlib.rs
@@ -331,7 +331,7 @@ fn builtin_string_parse_int(_eval: &mut Evaluator, call: MethodCall) -> Result<R
     call.call.check_arity_static("String.parse_int", &[])?;
     let string = call.receiver.expect_string();
 
-    match i64::from_str(string.as_ref()) {
+    match i64::from_str(string) {
         Ok(i) => Ok(Rc::new(Value::Int(i))),
         Err(..) => call
             .receiver_span


### PR DESCRIPTION
### Background

I’m [solving the Advent of Code in RCL](https://github.com/ruuda/adventofcode/blob/3e0017daf348aa498e7fbce259c4efbe6a07007d/2023/02/main.rcl), and for that I need a few methods, in particular string splitting. Advent of Code is a nice test for “real-world” usefulness; [Dhall fails this test](https://stackoverflow.com/a/54117241/135889).

### Methods and functions added

 * `List.fold`. Should there be a `Set.fold` as well? I’m not sure, but it’s not urgent, you can always make a list comprehension to turn the set into a list, and then fold.
 * `List.reverse`. I am on the fence about calling it `reverse` (imperative) or `reversed`. Python makes this distinction, but in Python lists are mutable. I already added `group_by` which is imperative, so I think I’ll go with imperative even for pure functions. In Haskell the pure `reverse` is also just called `reverse`.
 * `String.parse_int`
 * `String.split`
 * `String.split_lines`
 * `std.range`

### Drive by error reporting change

When writing the AoC solution in RCL, I made some mistakes that caused a missing field error, and seeing the actual value there would be very helpful. It is fairly easy to add a temporary trace, but just printing the value from the error is even nicer, and it’s something that not every language can easily do, but RCL can.

* One downside I can imagine is that the value could be huge and it spams the terminal, but that problem can be solved later.
* Another issue is that sometimes the value is rather trivial, for example when it just repeats a string literal from the source code. But even for a string literal, printing the value can be helpful when that string literal is a format string. Format holes don’t change the type though, so maybe it’s okay to not print the value if it’s a literal. But for now, consistency and simplicity are more important.

### Tasks

 * [x] Ensure documentation is up to date
 * [x] Ensure test coverage
 * [x] Run the fuzzer and confirm the fuzzer finds these new methods
 * [x] Figure out a good way to report errors from calls that are not initiated by user code. The current approach hides important errors emerging from the reduce function in a fold.