### PR TITLE
Add `List.join` and `String.replace` builtins

### DIFF
--- a/docs/type_list.md
+++ b/docs/type_list.md
@@ -62,6 +62,24 @@ foods.group_by(food => food.category)
 }
 ```
 
+## join
+
+    List.join: (self: List[T], separator: String) -> String
+
+Concatenate the elements with the separator in between. This is equivalent to
+using a format string, therefore the list elements must be string formattable.
+
+```rcl
+// Evaluates to "foo-bar".
+["foo", "bar"].join("-")
+
+// Evaluates to "2,3,5".
+[2, 3, 5].join(",")
+
+// Error, dicts are not string formattable.
+[{}, {}].join("")
+```
+
 ## key_by
 
     List.key_by: (self: List[T], get_key: T -> U) -> Dict[U, T]

--- a/docs/type_string.md
+++ b/docs/type_string.md
@@ -91,6 +91,17 @@ evaluation aborts with an error.
 "-42".parse_int()
 ```
 
+## replace
+
+    String.replace (self: String, needle: String, replacement: String) -> String
+
+Replace all occurrences of `needle` with `replacement`.
+
+```rcl
+// Evaluates to "I saw the microphone through the microscope".
+"I saw the telephone through the telescope".replace("tele", "micro")
+```
+
 ## split
 
     String.split: (self: String, separator: String) -> List[String]

--- a/docs/type_string.md
+++ b/docs/type_string.md
@@ -50,6 +50,14 @@ Return whether the string ends in `suffix`.
 "racecar".ends_with("ace")
 ```
 
+## join
+
+To concatenate list elements with a separator in between,
+use [`List.join`](type_list.md#join).
+(This entry is here to point people who are used to Python’s
+[`str.join`](https://docs.python.org/3/library/stdtypes.html#str.join)
+in the right direction.)
+
 ## len
 
     String.len: (self: String) -> Int

--- a/etc/pygments/rcl.py
+++ b/etc/pygments/rcl.py
@@ -69,6 +69,7 @@ _root_base = [
                 "keys",
                 "len",
                 "parse_int",
+                "replace",
                 "reverse",
                 "split",
                 "split_lines",

--- a/etc/pygments/rcl.py
+++ b/etc/pygments/rcl.py
@@ -64,6 +64,7 @@ _root_base = [
                 "fold",
                 "get",
                 "group_by",
+                "join",
                 "key_by",
                 "keys",
                 "len",

--- a/etc/rcl.vim/syntax/rcl.vim
+++ b/etc/rcl.vim/syntax/rcl.vim
@@ -44,7 +44,7 @@ syn region  rclFormatTriple  start='f"""' end='"""' skip='\\"\|\\{' contains=rcl
 
 " See also https://vi.stackexchange.com/questions/5966/ for why the `contains`
 " needs to end in `[]`.
-syn keyword rclBuiltin chars contains[] ends_with except fold get group_by join key_by keys len parse_int reverse split split_lines starts_with std values
+syn keyword rclBuiltin chars contains[] ends_with except fold get group_by join key_by keys len parse_int replace reverse split split_lines starts_with std values
 
 syn cluster rclString contains=rclStringDouble,rclStringTriple,rclFormatDouble,rclFormatTriple
 highlight link rclStringDouble rclString

--- a/etc/rcl.vim/syntax/rcl.vim
+++ b/etc/rcl.vim/syntax/rcl.vim
@@ -44,7 +44,7 @@ syn region  rclFormatTriple  start='f"""' end='"""' skip='\\"\|\\{' contains=rcl
 
 " See also https://vi.stackexchange.com/questions/5966/ for why the `contains`
 " needs to end in `[]`.
-syn keyword rclBuiltin chars contains[] ends_with except fold get group_by key_by keys len parse_int reverse split split_lines starts_with std values
+syn keyword rclBuiltin chars contains[] ends_with except fold get group_by join key_by keys len parse_int reverse split split_lines starts_with std values
 
 syn cluster rclString contains=rclStringDouble,rclStringTriple,rclFormatDouble,rclFormatTriple
 highlight link rclStringDouble rclString

--- a/fuzz/dictionary.txt
+++ b/fuzz/dictionary.txt
@@ -57,6 +57,7 @@
 "keys"
 "len"
 "parse_int"
+"replace"
 "reverse"
 "split"
 "split_lines"

--- a/fuzz/dictionary.txt
+++ b/fuzz/dictionary.txt
@@ -52,6 +52,7 @@
 "fold"
 "get"
 "group_by"
+"join"
 "key_by"
 "keys"
 "len"

--- a/golden/error/runtime_fstring_not_formattable.test
+++ b/golden/error/runtime_fstring_not_formattable.test
@@ -5,4 +5,6 @@ stdin:1:33
   ╷
 1 │ f"This cannot be interpolated: {{x = 1}.contains}."
   ╵                                 ^~~~~~~~~~~~~~~~
-Error: This value cannot be interpolated into a string.
+Error: This value cannot be interpolated into a string:
+
+  Dict.contains

--- a/golden/error/std_string_replace_not_string_needle.test
+++ b/golden/error/std_string_replace_not_string_needle.test
@@ -1,0 +1,14 @@
+"".replace(1, "")
+
+# output:
+stdin:1:12
+  ╷
+1 │ "".replace(1, "")
+  ╵            ^
+Error: Needle must be a string.
+
+stdin:1:11
+  ╷
+1 │ "".replace(1, "")
+  ╵           ^
+In call to method 'String.replace'.

--- a/golden/error/std_string_replace_not_string_replacement.test
+++ b/golden/error/std_string_replace_not_string_replacement.test
@@ -1,0 +1,14 @@
+"".replace("", 1)
+
+# output:
+stdin:1:16
+  ╷
+1 │ "".replace("", 1)
+  ╵                ^
+Error: Replacement must be a string.
+
+stdin:1:11
+  ╷
+1 │ "".replace("", 1)
+  ╵           ^
+In call to method 'String.replace'.

--- a/golden/json/fstring.test
+++ b/golden/json/fstring.test
@@ -5,13 +5,13 @@
   // Three parts, one inner fragment.
   f"Begin {"hole1"} inner {"hole2"} end.",
 
-  // With integers and booleans inside.
-  f"Bool: {not false}, integer: {21 + 21}",
+  // With integers, booleans, and null inside.
+  f"Bool: {not false}, integer: {21 + 21}, null: {null}",
 ]
 
 # output:
 [
   "Interpolated string: hello, world",
   "Begin hole1 inner hole2 end.",
-  "Bool: true, integer: 42"
+  "Bool: true, integer: 42, null: null"
 ]

--- a/golden/json/list_join.test
+++ b/golden/json/list_join.test
@@ -1,0 +1,4 @@
+["one", 2, "three"].join(" -- ")
+
+# output:
+"one -- 2 -- three"

--- a/golden/json/string_replace.test
+++ b/golden/json/string_replace.test
@@ -1,0 +1,4 @@
+"abacab".replace("ab", "ac")
+
+# output:
+"acacac"

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -519,9 +519,10 @@ impl<'a> Evaluator<'a> {
     /// This powers both format strings as well as `List.join`.
     pub fn push_format_fragment(out: &mut Vec<Rc<str>>, span: Span, value: &Value) -> Result<()> {
         match value {
-            Value::String(s) => out.push(s.clone()),
-            Value::Int(i) => out.push(i.to_string().into()),
             Value::Bool(b) => out.push((if *b { "true" } else { "false" }).into()),
+            Value::Int(i) => out.push(i.to_string().into()),
+            Value::Null => out.push("null".into()),
+            Value::String(s) => out.push(s.clone()),
             _ => {
                 // TODO: We could include the value itself into the message.
                 return span

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -272,6 +272,7 @@ impl<'a> Evaluator<'a> {
                     (Value::String(_), "ends_with") => Some(stdlib::STRING_ENDS_WITH),
                     (Value::String(_), "len") => Some(stdlib::STRING_LEN),
                     (Value::String(_), "parse_int") => Some(stdlib::STRING_PARSE_INT),
+                    (Value::String(_), "replace") => Some(stdlib::STRING_REPLACE),
                     (Value::String(_), "split") => Some(stdlib::STRING_SPLIT),
                     (Value::String(_), "split_lines") => Some(stdlib::STRING_SPLIT_LINES),
                     (Value::String(_), "starts_with") => Some(stdlib::STRING_STARTS_WITH),

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -14,7 +14,7 @@ use crate::ast::{BinOp, Expr, FormatFragment, Seq, Stmt, UnOp, Yield};
 use crate::error::{Error, IntoError, Result};
 use crate::fmt_rcl::{self, format_rcl};
 use crate::loader::Loader;
-use crate::pprint::{concat, Doc};
+use crate::pprint::{concat, indent, Doc};
 use crate::runtime::{CallArg, Env, Function, FunctionCall, MethodCall, Value};
 use crate::source::{DocId, Span};
 use crate::stdlib;
@@ -523,10 +523,14 @@ impl<'a> Evaluator<'a> {
             Value::Int(i) => out.push(i.to_string().into()),
             Value::Null => out.push("null".into()),
             Value::String(s) => out.push(s.clone()),
-            _ => {
-                // TODO: We could include the value itself into the message.
+            not_formattable => {
                 return span
-                    .error("This value cannot be interpolated into a string.")
+                    .error(concat! {
+                        "This value cannot be interpolated into a string:"
+                        Doc::HardBreak
+                        Doc::HardBreak
+                        indent! { format_rcl(not_formattable).into_owned() }
+                    })
                     .err();
             }
         }

--- a/src/highlight.rs
+++ b/src/highlight.rs
@@ -28,7 +28,7 @@ fn get_color(token: &Token, token_bytes: &[u8]) -> &'static str {
             // Give the builtins a different color.
             // TODO: Only when preceded by a dot, when they are methods.
             b"chars" | b"contains" | b"ends_with" | b"except" | b"fold" | b"get" | b"group_by"
-            | b"key_by" | b"keys" | b"len" | b"parse_int" | b"reverse" | b"split"
+            | b"join" | b"key_by" | b"keys" | b"len" | b"parse_int" | b"reverse" | b"split"
             | b"split_lines" | b"starts_with" | b"std" | b"values" => red,
             _ => blue,
         },

--- a/src/highlight.rs
+++ b/src/highlight.rs
@@ -28,8 +28,8 @@ fn get_color(token: &Token, token_bytes: &[u8]) -> &'static str {
             // Give the builtins a different color.
             // TODO: Only when preceded by a dot, when they are methods.
             b"chars" | b"contains" | b"ends_with" | b"except" | b"fold" | b"get" | b"group_by"
-            | b"join" | b"key_by" | b"keys" | b"len" | b"parse_int" | b"reverse" | b"split"
-            | b"split_lines" | b"starts_with" | b"std" | b"values" => red,
+            | b"join" | b"key_by" | b"keys" | b"len" | b"parse_int" | b"replace" | b"reverse"
+            | b"split" | b"split_lines" | b"starts_with" | b"std" | b"values" => red,
             _ => blue,
         },
 

--- a/src/stdlib.rs
+++ b/src/stdlib.rs
@@ -437,6 +437,31 @@ fn builtin_string_chars(_eval: &mut Evaluator, call: MethodCall) -> Result<Rc<Va
     Ok(Rc::new(Value::List(result)))
 }
 
+builtin_method!("String.replace", const STRING_REPLACE, builtin_string_replace);
+fn builtin_string_replace(_eval: &mut Evaluator, call: MethodCall) -> Result<Rc<Value>> {
+    call.call
+        .check_arity_static("String.replace", &["needle", "replacement"])?;
+    let string = call.receiver.expect_string();
+    let needle_arg = &call.call.args[0];
+    let needle = match needle_arg.value.as_ref() {
+        Value::String(s) => s.as_ref(),
+        _ => return needle_arg.span.error("Needle must be a string.").err(),
+    };
+    let replacement_arg = &call.call.args[1];
+    let replacement = match replacement_arg.value.as_ref() {
+        Value::String(s) => s.as_ref(),
+        _ => {
+            return replacement_arg
+                .span
+                .error("Replacement must be a string.")
+                .err()
+        }
+    };
+    Ok(Rc::new(Value::String(
+        string.replace(needle, replacement).into(),
+    )))
+}
+
 builtin_method!("List.fold", const LIST_FOLD, builtin_list_fold);
 fn builtin_list_fold(eval: &mut Evaluator, call: MethodCall) -> Result<Rc<Value>> {
     // TODO: Add static type checks. Right now you could provide a bogus


### PR DESCRIPTION
* [x] Ensure golden test coverage.
* [x] Ensure the fuzzer discovers these code paths.
* [x] Ensure documentation is up to date.

Drive-by changes:

 * Allow `null` in string interpolation.
 * For values that cannot be string-formatted, print the offending value as part of the error. (This sounds contradictory, but most types are not formattable in an obvious way, at some point I want to introduce specifier to choose how to format such values, e.g. as json.)