### PR TITLE
Don't eat comments between separator and closing delimiter

### DIFF
--- a/golden/fmt/comment_before_close.test
+++ b/golden/fmt/comment_before_close.test
@@ -1,0 +1,20 @@
+// Comments before closing delimiters should not be dropped.
+let xs = [
+  0,
+  // This is one example.
+];
+
+let ys = foobar(
+  0,
+  // This is another such example.
+);
+
+null
+
+# output:
+// Comments before closing delimiters should not be dropped.
+let xs = [0];
+
+let ys = foobar(0);
+
+null

--- a/golden/fmt/comment_before_close.test
+++ b/golden/fmt/comment_before_close.test
@@ -4,17 +4,47 @@ let xs = [
   // This is one example.
 ];
 
+let xs2 = [
+  // Even with empty collections, the comment should stay.
+];
+let xs3 = {
+  // And that is true of brace literals as well as bracket literals.
+};
+
 let ys = foobar(
   0,
-  // This is another such example.
+  // In a call, the comment should not be eaten either.
 );
+
+let f = (
+  x,
+  // And in an argument list, it should be preserved.
+) => x;
 
 null
 
 # output:
 // Comments before closing delimiters should not be dropped.
-let xs = [0];
+let xs = [
+  0,
+  // This is one example.
+];
 
-let ys = foobar(0);
+let xs2 = [
+  // Even with empty collections, the comment should stay.
+];
+let xs3 = {
+  // And that is true of brace literals as well as bracket literals.
+};
+
+let ys = foobar(
+  0,
+  // In a call, the comment should not be eaten either.
+);
+
+let f = (
+  x,
+  // And in an argument list, it should be preserved.
+) => x;
 
 null

--- a/src/abstraction.rs
+++ b/src/abstraction.rs
@@ -241,7 +241,9 @@ impl<'a> Abstractor<'a> {
                 field_span: *field,
             },
 
-            CExpr::Function { span, args, body } => AExpr::Function {
+            CExpr::Function {
+                span, args, body, ..
+            } => AExpr::Function {
                 span: *span,
                 args: args
                     .iter()

--- a/src/cst.rs
+++ b/src/cst.rs
@@ -165,6 +165,8 @@ pub enum Expr {
         open: Span,
         close: Span,
         elements: Box<[Prefixed<Seq>]>,
+        /// Any content before the closing brace.
+        suffix: Box<[NonCode]>,
     },
 
     /// A `[]`-enclosed collection literal.
@@ -172,6 +174,8 @@ pub enum Expr {
         open: Span,
         close: Span,
         elements: Box<[Prefixed<Seq>]>,
+        /// Any content before the closing bracket.
+        suffix: Box<[NonCode]>,
     },
 
     /// An expression enclosed in `()`.
@@ -236,6 +240,8 @@ pub enum Expr {
         /// The source location of the `=>`.
         span: Span,
         args: Box<[Prefixed<Span>]>,
+        /// Any non-code between the final arg and the closing paren.
+        suffix: Box<[NonCode]>,
         body: Box<Expr>,
     },
 
@@ -245,9 +251,13 @@ pub enum Expr {
         open: Span,
         /// The closing parenthesis.
         close: Span,
+        /// The span of the callee.
         function_span: Span,
+        /// The callee expression.
         function: Box<Expr>,
         args: Box<[SpanPrefixedExpr]>,
+        /// Any non-code between the final argument and the closing paren.
+        suffix: Box<[NonCode]>,
     },
 
     /// Index into a collection with `[]`.


### PR DESCRIPTION
There were some cases where non-code before a closing delimiter could be discarded, because we consumed it before discovering the closing delimiter. This happens in the real world, mostly when you have a collection and you comment out the last element. To fix this, put the non-code in the CST and emit it when formatting.

* [ ] Ensure test coverage.
* [ ] Ensure the fuzzer discovers these paths.