### PR TITLE
Add List.enumerate method

### DIFF
--- a/docs/type_list.md
+++ b/docs/type_list.md
@@ -14,6 +14,33 @@ Return whether the list contains a given element. For example:
 [true, false]
 ```
 
+## enumerate
+
+    List.enumerate: (self: List[T]) -> Dict[Int, T]
+
+Return a mapping from index to list element. The index is zero-based.
+
+```rcl
+["x", "y", "z"].enumerate()
+// Evaluates to:
+{ 0: "x", 1: "y", 2: "z" }
+```
+
+This is mostly useful for iterating:
+
+```rcl
+let pieces = ["pawn", "queen", "bisshop"];
+let unordered_pairs = [
+  for i, piece_i in pieces.enumerate():
+  for j in std.range(i + 1, pieces.len()):
+  let piece_j = pieces[j];
+  [piece_i, piece_j]
+];
+unordered_pairs
+// Evaluates to:
+[["pawn", "queen"], ["pawn", "bisshop"], ["queen", "bisshop"]]
+```
+
 ## fold
 
     List.fold: (self: List[T], seed: U, reduce: (U, T) -> U) -> U

--- a/etc/pygments/rcl.py
+++ b/etc/pygments/rcl.py
@@ -60,6 +60,7 @@ _root_base = [
                 "chars",
                 "contains",
                 "ends_with",
+                "enumerate",
                 "except",
                 "fold",
                 "get",

--- a/fuzz/dictionary.txt
+++ b/fuzz/dictionary.txt
@@ -48,6 +48,7 @@
 "chars"
 "contains"
 "ends_with"
+"enumerate"
 "except"
 "fold"
 "get"

--- a/golden/rcl/list_enumerate.test
+++ b/golden/rcl/list_enumerate.test
@@ -1,0 +1,4 @@
+["x", "y", "z"].enumerate()
+
+# output:
+{ 0: "x", 1: "y", 2: "z" }

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -307,6 +307,7 @@ impl<'a> Evaluator<'a> {
                     }
 
                     (Value::List(_), "contains") => Some(&stdlib::LIST_CONTAINS),
+                    (Value::List(_), "enumerate") => Some(&stdlib::LIST_ENUMERATE),
                     (Value::List(_), "fold") => Some(&stdlib::LIST_FOLD),
                     (Value::List(_), "group_by") => Some(&stdlib::LIST_GROUP_BY),
                     (Value::List(_), "join") => Some(&stdlib::LIST_JOIN),

--- a/src/highlight.rs
+++ b/src/highlight.rs
@@ -27,9 +27,9 @@ fn get_color(token: &Token, token_bytes: &[u8]) -> &'static str {
         Token::Ident => match token_bytes {
             // Give the builtins a different color.
             // TODO: Only when preceded by a dot, when they are methods.
-            b"chars" | b"contains" | b"ends_with" | b"except" | b"fold" | b"get" | b"group_by"
-            | b"join" | b"key_by" | b"keys" | b"len" | b"parse_int" | b"replace" | b"reverse"
-            | b"split" | b"split_lines" | b"starts_with" | b"std" | b"values" => red,
+            b"chars" | b"contains" | b"ends_with" | b"enumerate" | b"except" | b"fold" | b"get"
+            | b"group_by" | b"join" | b"key_by" | b"keys" | b"len" | b"parse_int" | b"replace"
+            | b"reverse" | b"split" | b"split_lines" | b"starts_with" | b"std" | b"values" => red,
             _ => blue,
         },
 

--- a/src/stdlib.rs
+++ b/src/stdlib.rs
@@ -522,3 +522,15 @@ fn builtin_list_reverse(_eval: &mut Evaluator, call: MethodCall) -> Result<Value
     let reversed = list.iter().rev().cloned().collect();
     Ok(Value::List(Rc::new(reversed)))
 }
+
+builtin_method!("List.enumerate", const LIST_ENUMERATE, builtin_list_enumerate);
+fn builtin_list_enumerate(_eval: &mut Evaluator, call: MethodCall) -> Result<Value> {
+    call.call.check_arity_static("List.enumerate", &[])?;
+    let list = call.receiver.expect_list();
+    let kv: BTreeMap<_, _> = list
+        .iter()
+        .zip(0..)
+        .map(|(v, i)| (Value::Int(i), v.clone()))
+        .collect();
+    Ok(Value::Dict(Rc::new(kv)))
+}


### PR DESCRIPTION
I've found I needed this in a few places. You can already do it by iterating over std.range:

    [for i, v in xs.enumerate(): ...]

is equivalent to

    [
      for i in std.range(0, xs.len()):
      let v = xs[i];
      ...
    ]

but having it built-in is just slightly more convenient. It's a bit of a shame that we have to construct the entire dict just to iterate over it, but the focus of RCL right now is not performance.

* [x] Ensure documentation is up to date.
* [x] Ensure new code has test coverage.
* [x] Ensure the fuzzer can discover interesting inputs.