### PR TITLE
Add evaluation limit

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -150,6 +150,7 @@
               debugBuild = packages.default.overrideAttrs (old: {
                 name = "check-test";
                 buildType = "debug";
+                RUSTFLAGS = "-C debug-assertions";
               });
 
               golden = pkgs.runCommand

--- a/golden/error/recursion_timeout.test
+++ b/golden/error/recursion_timeout.test
@@ -1,0 +1,46 @@
+// This is a regression test. This input used to hang indefinitely.
+// The outer g on the gg is required, without it we terminate to a function.
+// The inner g on the gg is required as well, otherwise we also terminate.
+// The k in "h => k => ..." is also needed, without it we do hit stack error.
+// In the inner call gg(h), if we use gg(k) instead, we also hit stack error.
+let f = g => g(g(h => k => g(g(h))));
+f(f)
+
+# output:
+stdin:6:31
+  ╷
+6 │ let f = g => g(g(h => k => g(g(h))));
+  ╵                               ^
+Error: Evaluation budget exceeded. This expression exceeds the maximum of 10000 steps.
+
+stdin:6:17
+  ╷
+6 │ let f = g => g(g(h => k => g(g(h))));
+  ╵                 ^
+In call to function.
+
+stdin:6:29
+  ╷
+6 │ let f = g => g(g(h => k => g(g(h))));
+  ╵                             ^
+In call to function.
+
+stdin:6:15
+  ╷
+6 │ let f = g => g(g(h => k => g(g(h))));
+  ╵               ^
+In call to function.
+
+stdin:6:29
+  ╷
+6 │ let f = g => g(g(h => k => g(g(h))));
+  ╵                             ^
+In call to function.
+
+stdin:6:17
+  ╷
+6 │ let f = g => g(g(h => k => g(g(h))));
+  ╵                 ^
+In call to function.
+
+Note: The call stack is too deep to display in full. Only the innermost calls are shown above.

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -62,9 +62,15 @@ pub fn check_value(at: Span, type_: &Type, value: &Value) -> Result<()> {
             check_function_value(at, fn_type, fn_val)
         }
         (Type::Function { .. }, Value::BuiltinFunction { .. }) => {
+            #[cfg(fuzzing)]
+            return Ok(());
+            #[cfg(not(fuzzing))]
             unimplemented!("TODO: Typecheck function for BuiltinFunction.")
         }
         (Type::Function { .. }, Value::BuiltinMethod { .. }) => {
+            #[cfg(fuzzing)]
+            return Ok(());
+            #[cfg(not(fuzzing))]
             unimplemented!("TODO: Typecheck function for BuiltinMethod.")
         }
 


### PR DESCRIPTION
The fuzzer has discovered some interesting programs that diverge, in particular this one:

```
let f = g => g(g(h => k => g(g(h))));
f(f)
```

It still puzzles me: it loops infinitely without causing a stack overflow. To make sure the fuzzer doesn’t get stuck on cases like these, add a limit on the number of evaluation steps. Perhaps in the future it should be configurable for people who want to evaluate huge documents for legitimate reasons, but for now a hard-coded limit works fine.

(This is extracted from #26, I added it there first, but I keep running into this and that big pull request will take some time to get merged. So it’s good to extract pieces that can be merged already.)