### PR TITLE
Add support for TOML output format

### DIFF
--- a/docs/rcl_evaluate.md
+++ b/docs/rcl_evaluate.md
@@ -28,6 +28,8 @@ Output in the given format. The following formats are supported:
   a list or set of strings, output each string on its own line.</dd>
   <dt>rcl</dt>
   <dd>Output pretty-printed <abbr>RCL</abbr>.</dd>
+  <dt>toml</dt>
+  <dd>Output <abbr>TOML</abbr>.</dd>
 </dl>
 
 The default output format is `rcl`. For the `je` command shorthand, the default

--- a/golden/run.py
+++ b/golden/run.py
@@ -97,6 +97,8 @@ def test_one(fname: str, fname_friendly: str, *, rewrite_output: bool) -> Option
             cmd = ["eval", "--output=raw"]
         case "rcl":
             cmd = ["eval", "--output=rcl"]
+        case "toml":
+            cmd = ["eval", "--output=toml"]
         case unknown:
             raise ValueError(f"No command-line known for {unknown}.")
 

--- a/golden/toml/array.test
+++ b/golden/toml/array.test
@@ -1,0 +1,27 @@
+{
+  simple = [21, 42],
+  advanced = [21, 42, "yes", { x = 1, y = 2 }, [999, 999], {}],
+  empty = [],
+  multi-line = {
+    but-nested = [
+      { name = "Leon Kowalski", model = "Nexus-6" },
+      { name = "Pris Stratton", model = "Nexus-6" },
+      { name = "Rachael", model = "Nexus-7" },
+      { name = "Roy Batty", model = "Nexus-6" },
+      { "s p a c e": { for x in []: x } },
+    ],
+  },
+}
+
+# output:
+advanced = [21, 42, "yes", { x = 1, y = 2 }, [999, 999], {}]
+simple = [21, 42]
+
+[multi-line]
+but-nested = [
+  { model = "Nexus-6", name = "Leon Kowalski" },
+  { model = "Nexus-6", name = "Pris Stratton" },
+  { model = "Nexus-7", name = "Rachael" },
+  { model = "Nexus-6", name = "Roy Batty" },
+  { "s p a c e" = [] },
+]

--- a/golden/toml/error_function_builtin.test
+++ b/golden/toml/error_function_builtin.test
@@ -1,0 +1,12 @@
+{
+  range = std.range,
+}
+
+# output:
+stdin:1:1
+  ╷
+1 │ {
+  ╵ ^
+in value
+at key "range"
+Error: Functions cannot be exported as TOML.

--- a/golden/toml/error_function_lambda.test
+++ b/golden/toml/error_function_lambda.test
@@ -1,0 +1,12 @@
+{
+  function = x => "Functions are not serializable as TOML.",
+}
+
+# output:
+stdin:1:1
+  ╷
+1 │ {
+  ╵ ^
+in value
+at key "function"
+Error: Functions cannot be exported as TOML.

--- a/golden/toml/error_function_method.test
+++ b/golden/toml/error_function_method.test
@@ -1,0 +1,12 @@
+{
+  method = "Not exportable as TOML.".len
+}
+
+# output:
+stdin:1:1
+  ╷
+1 │ {
+  ╵ ^
+in value
+at key "method"
+Error: Methods cannot be exported as TOML.

--- a/golden/toml/error_key_not_string.test
+++ b/golden/toml/error_key_not_string.test
@@ -1,0 +1,10 @@
+{
+  42: "The answer",
+}
+
+# output:
+stdin:1:1
+  ╷
+1 │ {
+  ╵ ^
+Error: To export as TOML, keys must be strings.

--- a/golden/toml/error_not_dict.test
+++ b/golden/toml/error_not_dict.test
@@ -1,0 +1,8 @@
+"This cannot directly be formatted as TOML."
+
+# output:
+stdin:1:1
+  ╷
+1 │ "This cannot directly be formatted as TOML."
+  ╵ ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Error: To format as TOML, the top-level value must be a dict.

--- a/golden/toml/error_null.test
+++ b/golden/toml/error_null.test
@@ -1,0 +1,22 @@
+// This test tests both that serializing `null` is an error,
+// and that the context of the error is reported properly.
+{
+  outer = {
+    inner = [
+      "first",
+      null,
+      "last",
+    ]
+  }
+}
+
+# output:
+stdin:1:1
+  ╷
+1 │ // This test tests both that serializing `null` is an error,
+  ╵ ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+in value
+at index 1
+at key "inner"
+at key "outer"
+Error: Null cannot be exported as TOML.

--- a/golden/toml/keys_quoted.test
+++ b/golden/toml/keys_quoted.test
@@ -1,0 +1,19 @@
+// This tests that keys get quoted when necessary.
+{
+  "042": "Seemingly integer key",
+  _underscores_are_ok = true,
+  dashes-are-ok = true,
+  "-start-dashes-too": "of course",
+  "spaces are ok": false,
+  "schreibökonomisch": "certainly not",
+  "": "allowed but discouraged",
+}
+
+# output:
+"" = "allowed but discouraged"
+-start-dashes-too = "of course"
+042 = "Seemingly integer key"
+_underscores_are_ok = true
+dashes-are-ok = true
+"schreibökonomisch" = "certainly not"
+"spaces are ok" = false

--- a/golden/toml/string.test
+++ b/golden/toml/string.test
@@ -1,0 +1,15 @@
+{
+  name = "Rachael",
+  model = "Nexus-7",
+  // A multi-line string should be escaped.
+  description =
+    """
+    With her Voight-Kampff test, it took over
+    one hundred questions to determine her nature.
+    """,
+}
+
+# output:
+description = "With her Voight-Kampff test, it took over\none hundred questions to determine her nature.\n"
+model = "Nexus-7"
+name = "Rachael"

--- a/golden/toml/top_level_all.test
+++ b/golden/toml/top_level_all.test
@@ -1,0 +1,41 @@
+// This test tests how the different sections (bare keys, tables, and tables in
+// arrays) are appended.
+{
+  bare_key = true,
+
+  package = {
+    name = "rcl",
+    edition = "2021",
+    license = "Apache-2.0",
+  },
+
+  dependencies = {
+    unicode-width = "0.1.10",
+  },
+
+  bin = [
+    { name = "rcl", test = true, bench = false },
+    { name = "fuzz-main", test = false, bench = false },
+  ],
+}
+
+# output:
+bare_key = true
+
+[dependencies]
+unicode-width = "0.1.10"
+
+[package]
+edition = "2021"
+license = "Apache-2.0"
+name = "rcl"
+
+[[bin]]
+bench = false
+name = "rcl"
+test = true
+
+[[bin]]
+bench = false
+name = "fuzz-main"
+test = false

--- a/golden/toml/top_level_dict.test
+++ b/golden/toml/top_level_dict.test
@@ -1,0 +1,19 @@
+{
+  rbatty = {
+    name = "Roy Batty",
+    model = "Nexus-6",
+  },
+  rachael = {
+    name = "Rachael Tyrell",
+    model = "Nexus-7",
+  },
+}
+
+# output:
+[rachael]
+model = "Nexus-7"
+name = "Rachael Tyrell"
+
+[rbatty]
+model = "Nexus-6"
+name = "Roy Batty"

--- a/golden/toml/top_level_list_of_dict.test
+++ b/golden/toml/top_level_list_of_dict.test
@@ -1,0 +1,25 @@
+{
+  users = [
+    {
+      username = "rbatty",
+      name = "Roy Batty",
+      model = "Nexus-6",
+    },
+    {
+      username = "rachael",
+      name = "Rachael Tyrell",
+      model = "Nexus-7",
+    },
+  ],
+}
+
+# output:
+[[users]]
+model = "Nexus-6"
+name = "Roy Batty"
+username = "rbatty"
+
+[[users]]
+model = "Nexus-7"
+name = "Rachael Tyrell"
+username = "rachael"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -78,6 +78,7 @@ Output modes:
                 document is a list or set of strings, output each string on its
                 own line.
   rcl           Output pretty-printed RCL.
+  toml          Output TOML.
 
 Sandboxing modes:
   workdir       Only allow importing files inside the working directory and
@@ -130,6 +131,7 @@ pub enum OutputFormat {
     Raw,
     #[default]
     Rcl,
+    Toml,
 }
 
 /// Options for commands that evaluate expressions.
@@ -239,6 +241,7 @@ pub fn parse(args: Vec<String>) -> Result<(GlobalOptions, Cmd)> {
                     "json" => OutputFormat::Json,
                     "raw" => OutputFormat::Raw,
                     "rcl" => OutputFormat::Rcl,
+                    "toml" => OutputFormat::Toml,
                 }
             }
             Arg::Long("sandbox") => {
@@ -561,7 +564,7 @@ mod test {
         );
         assert_eq!(
             fail_parse(&["rcl", "eval", "infile", "--output=yamr"]),
-            "Error: Expected --output to be followed by one of json, raw, rcl. See --help for usage.\n"
+            "Error: Expected --output to be followed by one of json, raw, rcl, toml. See --help for usage.\n"
         );
         assert_eq!(
             fail_parse(&["rcl", "frobnicate", "infile"]),

--- a/src/fmt_toml.rs
+++ b/src/fmt_toml.rs
@@ -24,7 +24,7 @@ pub fn format_toml(caller: Span, v: &Value) -> Result<Doc> {
 
     match v {
         Value::Dict(kv) => formatter.top_level(kv),
-        _ => formatter.error("Expected a dict for TOML format."),
+        _ => formatter.error("To format as TOML, the top-level value must be a dict."),
     }
 }
 
@@ -96,6 +96,8 @@ impl Formatter {
                 self.path.push(PathElement::Key(k_str.clone()));
                 Ok(self.key(k_str).with_markup(Markup::Identifier))
             }
+            // TODO: If value path allowed non-string keys, then we could
+            // include the key itself in the error.
             _ => self.error("To export as TOML, keys must be strings."),
         }
     }

--- a/src/fmt_toml.rs
+++ b/src/fmt_toml.rs
@@ -1,0 +1,76 @@
+// RCL -- A reasonable configuration language.
+// Copyright 2024 Ruud van Asseldonk
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// A copy of the License has been included in the root of the repository.
+
+//! Formatter that prints values as TOML.
+//!
+//! This formatter is similar to the one in [`fmt_json`].
+
+use crate::error::Result;
+use crate::markup::Markup;
+use crate::pprint::{concat, group, indent, Doc};
+use crate::runtime::Value;
+use crate::source::Span;
+use crate::string::escape_json;
+
+/// Render a value as TOML.
+pub fn format_toml(_span: Span, v: &Value) -> Result<Doc> {
+    Ok(value(v))
+}
+
+/// Format a string.
+fn string<'a>(s: &str) -> Doc<'a> {
+    let mut into = String::with_capacity(s.len());
+    // Note, json escaping works unmodified for TOML too, the characters that
+    // need escaping are identical and with the same escape sequences (which
+    // TOML probably did on purpose). <https://toml.io/en/v1.0.0#string>
+    escape_json(s, &mut into);
+    concat! { "\"" into "\"" }
+}
+
+fn list<'a>(open: &'a str, close: &'a str, vs: impl Iterator<Item = &'a Value>) -> Doc<'a> {
+    let mut elements = Vec::new();
+    for v in vs {
+        if !elements.is_empty() {
+            elements.push(",".into());
+            elements.push(Doc::Sep);
+        }
+        elements.push(value(v));
+    }
+
+    if elements.is_empty() {
+        // An empty collection we always format without space in between.
+        concat! { open close }
+    } else {
+        // Add a trailing comma in tall mode.
+        elements.push(Doc::tall(","));
+
+        group! {
+            open
+            Doc::SoftBreak
+            indent! { Doc::Concat(elements) }
+            Doc::SoftBreak
+            close
+        }
+    }
+}
+
+pub fn dict<'a>(_vs: impl Iterator<Item = (&'a Value, &'a Value)>) -> Doc<'a> {
+    unimplemented!("TODO: Toml inline tables.");
+}
+
+fn value(v: &Value) -> Doc {
+    match v {
+        Value::Bool(true) => Doc::from("true").with_markup(Markup::Keyword),
+        Value::Bool(false) => Doc::from("false").with_markup(Markup::Keyword),
+        Value::Int(i) => Doc::from(i.to_string()).with_markup(Markup::Number),
+        Value::String(s) => string(s).with_markup(Markup::String),
+        Value::List(vs) => list("[", "]", vs.iter()),
+        Value::Set(vs) => list("[", "]", vs.iter()),
+        Value::Dict(vs) => dict(vs.iter()),
+        _ => unimplemented!("TODO: Toml formatter errors."),
+    }
+}

--- a/src/fmt_toml.rs
+++ b/src/fmt_toml.rs
@@ -9,7 +9,9 @@
 //!
 //! This formatter is similar to the one in [`fmt_json`].
 
-use crate::error::Result;
+use std::collections::BTreeMap;
+
+use crate::error::{IntoError, PathElement, Result};
 use crate::markup::Markup;
 use crate::pprint::{concat, group, indent, Doc};
 use crate::runtime::Value;
@@ -17,60 +19,213 @@ use crate::source::Span;
 use crate::string::escape_json;
 
 /// Render a value as TOML.
-pub fn format_toml(_span: Span, v: &Value) -> Result<Doc> {
-    Ok(value(v))
-}
+pub fn format_toml(caller: Span, v: &Value) -> Result<Doc> {
+    let mut formatter = Formatter::new(caller);
 
-/// Format a string.
-fn string<'a>(s: &str) -> Doc<'a> {
-    let mut into = String::with_capacity(s.len());
-    // Note, json escaping works unmodified for TOML too, the characters that
-    // need escaping are identical and with the same escape sequences (which
-    // TOML probably did on purpose). <https://toml.io/en/v1.0.0#string>
-    escape_json(s, &mut into);
-    concat! { "\"" into "\"" }
-}
-
-fn list<'a>(open: &'a str, close: &'a str, vs: impl Iterator<Item = &'a Value>) -> Doc<'a> {
-    let mut elements = Vec::new();
-    for v in vs {
-        if !elements.is_empty() {
-            elements.push(",".into());
-            elements.push(Doc::Sep);
-        }
-        elements.push(value(v));
-    }
-
-    if elements.is_empty() {
-        // An empty collection we always format without space in between.
-        concat! { open close }
-    } else {
-        // Add a trailing comma in tall mode.
-        elements.push(Doc::tall(","));
-
-        group! {
-            open
-            Doc::SoftBreak
-            indent! { Doc::Concat(elements) }
-            Doc::SoftBreak
-            close
-        }
-    }
-}
-
-pub fn dict<'a>(_vs: impl Iterator<Item = (&'a Value, &'a Value)>) -> Doc<'a> {
-    unimplemented!("TODO: Toml inline tables.");
-}
-
-fn value(v: &Value) -> Doc {
     match v {
-        Value::Bool(true) => Doc::from("true").with_markup(Markup::Keyword),
-        Value::Bool(false) => Doc::from("false").with_markup(Markup::Keyword),
-        Value::Int(i) => Doc::from(i.to_string()).with_markup(Markup::Number),
-        Value::String(s) => string(s).with_markup(Markup::String),
-        Value::List(vs) => list("[", "]", vs.iter()),
-        Value::Set(vs) => list("[", "]", vs.iter()),
-        Value::Dict(vs) => dict(vs.iter()),
-        _ => unimplemented!("TODO: Toml formatter errors."),
+        Value::Dict(kv) => formatter.top_level(kv),
+        _ => formatter.error("Expected a dict for TOML format."),
+    }
+}
+
+/// Helper for formatting values as TOML.
+///
+/// The formatter tracks the path in the value that we are formatting from, such
+/// that we can report the location of an error, in case an error occurs.
+struct Formatter {
+    /// The source location where TOML formatting was triggered from.
+    caller: Span,
+
+    /// Where we currently are in the value to be formatted.
+    path: Vec<PathElement>,
+}
+
+impl Formatter {
+    pub fn new(caller: Span) -> Formatter {
+        Formatter {
+            caller,
+            path: Vec::new(),
+        }
+    }
+
+    /// Report an error at the current value path.
+    fn error<T>(&mut self, message: &'static str) -> Result<T> {
+        // Steal the path from the formatter and move it into the error. We have
+        // to leave an empty path in its place. This is fine, because returning
+        // the error prevents further formatting.
+        let mut path = Vec::new();
+        std::mem::swap(&mut self.path, &mut path);
+        self.caller.error(message).with_path(path).err()
+    }
+
+    /// Format a string.
+    fn string<'a>(&self, s: &str) -> Doc<'a> {
+        let mut into = String::with_capacity(s.len());
+        // Note, json escaping works unmodified for TOML too, the characters that
+        // need escaping are identical and with the same escape sequences (which
+        // TOML probably did on purpose). <https://toml.io/en/v1.0.0#string>
+        escape_json(s, &mut into);
+        concat! { "\"" into "\"" }
+    }
+
+    /// Format as a key in a key-value pair, or table header (without brackets).
+    fn key<'a>(&self, ident: &'a str) -> Doc<'a> {
+        let bytes = ident.as_bytes();
+
+        if bytes.is_empty() {
+            return "\"\"".into();
+        }
+
+        // If the key is ASCII alphanumeric, underscores, or dashes, then we can
+        // use it unquoted. <https://toml.io/en/v1.0.0#keys> Even if it starts
+        // with a digit.
+        if bytes
+            .iter()
+            .all(|b| b.is_ascii_alphanumeric() || *b == b'_' || *b == b'-')
+        {
+            ident.into()
+        } else {
+            self.string(ident)
+        }
+    }
+
+    /// Format a key, and push it to as path, or return an error on non-strings.
+    fn push_key<'a>(&mut self, key: &'a Value) -> Result<Doc<'a>> {
+        match key {
+            Value::String(k_str) => {
+                self.path.push(PathElement::Key(k_str.clone()));
+                Ok(self.key(k_str).with_markup(Markup::Identifier))
+            }
+            _ => self.error("To export as TOML, keys must be strings."),
+        }
+    }
+
+    /// Format a list as a TOML array.
+    fn array<'a>(&mut self, vs: impl Iterator<Item = &'a Value>) -> Result<Doc<'a>> {
+        let mut elements = Vec::new();
+        for (i, v) in vs.enumerate() {
+            if !elements.is_empty() {
+                elements.push(",".into());
+                elements.push(Doc::Sep);
+            }
+            self.path.push(PathElement::Index(i));
+            elements.push(self.value(v)?);
+            self.path.pop().expect("Push and pop are balanced.");
+        }
+
+        let result = if elements.is_empty() {
+            // An empty collection we always format without space in between.
+            "[]".into()
+        } else {
+            // Add a trailing comma in tall mode.
+            elements.push(Doc::tall(","));
+
+            group! {
+                "["
+                Doc::SoftBreak
+                indent! { Doc::Concat(elements) }
+                Doc::SoftBreak
+                "]"
+            }
+        };
+
+        Ok(result)
+    }
+
+    /// Format a dict as a TOML "inline table".
+    pub fn inline_table<'a>(
+        &mut self,
+        _vs: impl Iterator<Item = (&'a Value, &'a Value)>,
+    ) -> Result<Doc<'a>> {
+        unimplemented!("TODO: Toml inline tables.");
+    }
+
+    /// Format a key-value pair. <https://toml.io/en/v1.0.0#keyvalue-pair>
+    fn key_value<'a>(&mut self, key: &'a Value, value: &'a Value) -> Result<Doc<'a>> {
+        let result = concat! {
+            self.push_key(key)? " = " self.value(value)? Doc::HardBreak
+        };
+        self.path.pop().expect("We pushed the key before.");
+        Ok(result)
+    }
+
+    /// Format a dict as (top-level) table body.
+    fn table<'a>(&mut self, vs: impl Iterator<Item = (&'a Value, &'a Value)>) -> Result<Doc<'a>> {
+        let mut doc = Doc::empty();
+        for (k, v) in vs {
+            doc = doc + self.key_value(k, v)?
+        }
+        Ok(doc)
+    }
+
+    fn value<'a>(&mut self, v: &'a Value) -> Result<Doc<'a>> {
+        let result = match v {
+            Value::Null => self.error("Null cannot be exported as TOML.")?,
+            Value::Bool(true) => Doc::from("true").with_markup(Markup::Keyword),
+            Value::Bool(false) => Doc::from("false").with_markup(Markup::Keyword),
+            Value::Int(i) => Doc::from(i.to_string()).with_markup(Markup::Number),
+            Value::String(s) => self.string(s).with_markup(Markup::String),
+            Value::List(vs) => self.array(vs.iter())?,
+            // TOML has no set type, we format sets as arrays (lists).
+            Value::Set(vs) => self.array(vs.iter())?,
+            Value::Dict(vs) => self.inline_table(vs.iter())?,
+            Value::Function(..) => self.error("Functions cannot be exported as TOML.")?,
+            Value::BuiltinFunction(..) => self.error("Functions cannot be exported as TOML.")?,
+            Value::BuiltinMethod { .. } => self.error("Methods cannot be exported as TOML.")?,
+        };
+        Ok(result)
+    }
+
+    fn top_level<'a>(&mut self, kv: &'a BTreeMap<Value, Value>) -> Result<Doc<'a>> {
+        let mut values: Vec<Doc> = Vec::new();
+        let mut tables: Vec<Doc> = Vec::new();
+        let mut arrays: Vec<Doc> = Vec::new();
+
+        for (k, v) in kv {
+            match v {
+                // List of dicts has a special "Array of Tables" syntax in TOML.
+                // <https://toml.io/en/v1.0.0#array-of-tables>
+                Value::List(xs) if xs.iter().all(|x| matches!(x, Value::Dict(..))) => {
+                    let table_header = self.push_key(k)?;
+                    for (i, x) in xs.iter().enumerate() {
+                        self.path.push(PathElement::Index(i));
+                        let table_body = match x {
+                            Value::Dict(table_inner) => self.table(table_inner.iter())?,
+                            _ => unreachable!("We checked before that all elements are dicts."),
+                        };
+                        self.path.pop().expect("We pushed the index before.");
+                        arrays.push(concat! {
+                            "[[" table_header.clone() "]]"
+                            Doc::HardBreak
+                            table_body
+                        });
+                    }
+                }
+                // Top-level dicts get formatted as tables.
+                Value::Dict(table_inner) => {
+                    let table_header = self.push_key(k)?;
+                    let table_body = self.table(table_inner.iter())?;
+                    self.path.pop().expect("We pushed the key before.");
+                    tables.push(concat! {
+                        "[" table_header "]"
+                        Doc::HardBreak
+                        table_body
+                    });
+                }
+                // Anything else becomes a top-level key-value.
+                top_level_value => values.push(self.key_value(k, top_level_value)?),
+            }
+        }
+
+        // We put the top-level values first, then tables, then arrays.
+        for table in tables.into_iter().chain(arrays.into_iter()) {
+            // Separate tables by a blank line.
+            if !values.is_empty() {
+                values.push(Doc::HardBreak);
+            }
+            values.push(table);
+        }
+
+        Ok(Doc::Concat(values))
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,7 @@ pub mod fmt_cst;
 pub mod fmt_json;
 pub mod fmt_raw;
 pub mod fmt_rcl;
+pub mod fmt_toml;
 pub mod fmt_type;
 pub mod highlight;
 pub mod lexer;

--- a/src/main.rs
+++ b/src/main.rs
@@ -67,9 +67,10 @@ impl App {
         value: &Value,
     ) -> Result<()> {
         let out_doc = match eval_opts.format {
+            OutputFormat::Json => rcl::fmt_json::format_json(value_span, value)?,
             OutputFormat::Raw => rcl::fmt_raw::format_raw(value_span, value)?,
             OutputFormat::Rcl => rcl::fmt_rcl::format_rcl(value),
-            OutputFormat::Json => rcl::fmt_json::format_json(value_span, value)?,
+            OutputFormat::Toml => rcl::fmt_toml::format_toml(value_span, value)?,
         };
         self.print_doc_stdout(format_opts, out_doc);
         Ok(())


### PR DESCRIPTION
This adds [TOML](https://toml.io/en/v1.0.0) as a new output format.

* [x] Ensure docs are up to date.
* [x] Ensure golden test coverage.
* [x] Ensure the fuzzer discovers interesting inputs.