### PR TITLE
Add yaml-stream output format

### DIFF
--- a/docs/rcl_evaluate.md
+++ b/docs/rcl_evaluate.md
@@ -23,13 +23,21 @@ Output in the given format. The following formats are supported:
 <dl>
   <dt>json</dt>
   <dd>Output pretty-printed <abbr>JSON</abbr>.</dd>
+
   <dt>raw</dt>
   <dd>If the document is a string, output the string itself. If the document is
   a list or set of strings, output each string on its own line.</dd>
+
   <dt>rcl</dt>
   <dd>Output pretty-printed <abbr>RCL</abbr>.</dd>
+
   <dt>toml</dt>
   <dd>Output <abbr>TOML</abbr>.</dd>
+
+  <dt>yaml-stream</dt>
+  <dd>If the document is a list, output every element as a <abbr>JSON</abbr>
+  document, prefixed by the <code>---</code> <abbr>YAML</abbr> document
+  separator. Top-level values other than lists are not valid for this format.</dd>
 </dl>
 
 The default output format is `rcl`. For the `je` command shorthand, the default

--- a/golden/run.py
+++ b/golden/run.py
@@ -99,6 +99,8 @@ def test_one(fname: str, fname_friendly: str, *, rewrite_output: bool) -> Option
             cmd = ["eval", "--output=rcl"]
         case "toml":
             cmd = ["eval", "--output=toml"]
+        case "yaml_stream":
+            cmd = ["eval", "--output=yaml-stream"]
         case unknown:
             raise ValueError(f"No command-line known for {unknown}.")
 

--- a/golden/yaml_stream/list.test
+++ b/golden/yaml_stream/list.test
@@ -1,0 +1,34 @@
+[
+  {
+    apiVersion = "v1",
+    kind = "Service",
+    metadata = { name = "frobnicator", namespace = "default" },
+  },
+  {
+    apiVersion = "v1",
+    kind = "ConfigMap",
+    metadata = { name = "frobnicator-config" },
+    data = {
+      "config.toml":
+        """
+        [frobnicator]
+        level = 11
+        """
+    }
+  }
+]
+
+# output:
+---
+{
+  "apiVersion": "v1",
+  "kind": "Service",
+  "metadata": {"name": "frobnicator", "namespace": "default"}
+}
+---
+{
+  "apiVersion": "v1",
+  "data": {"config.toml": "[frobnicator]\nlevel = 11\n"},
+  "kind": "ConfigMap",
+  "metadata": {"name": "frobnicator-config"}
+}

--- a/golden/yaml_stream/not_list.test
+++ b/golden/yaml_stream/not_list.test
@@ -1,0 +1,11 @@
+{
+  name = "Not allowed",
+  description = "The top level value must be a list for yaml-stream.",
+}
+
+# output:
+stdin:1:1
+  ╷
+1 │ {
+  ╵ ^
+Error: To format as YAML stream, the top-level value must be a list.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -66,19 +66,22 @@ Arguments:
              file is bound to the variable 'input'.
 
 Options:
-  -o --output <format>  Output format, can be one of 'json', 'raw', 'rcl', see
-                        below. Defaults to 'rcl'.
+  -o --output <format>  Output format, see below for the available formats.
+                        Defaults to 'rcl'.
   -w --width <width>    Target width for pretty-printing, must be an integer.
                         Defaults to 80.
   --sandbox <mode>      Sandboxing mode, see below. Defaults to 'workdir'.
 
-Output modes:
+Output format:
   json          Output pretty-printed JSON.
   raw           If the document is a string, output the string itself. If the
                 document is a list or set of strings, output each string on its
                 own line.
   rcl           Output pretty-printed RCL.
   toml          Output TOML.
+  yaml-stream   If the document is a list, output every element as a JSON
+                document, prefixed by the '---' YAML document separator.
+                Top-level values other than lists are not valid for this format.
 
 Sandboxing modes:
   workdir       Only allow importing files inside the working directory and
@@ -132,6 +135,7 @@ pub enum OutputFormat {
     #[default]
     Rcl,
     Toml,
+    YamlStream,
 }
 
 /// Options for commands that evaluate expressions.
@@ -242,6 +246,7 @@ pub fn parse(args: Vec<String>) -> Result<(GlobalOptions, Cmd)> {
                     "raw" => OutputFormat::Raw,
                     "rcl" => OutputFormat::Rcl,
                     "toml" => OutputFormat::Toml,
+                    "yaml-stream" => OutputFormat::YamlStream,
                 }
             }
             Arg::Long("sandbox") => {
@@ -564,7 +569,7 @@ mod test {
         );
         assert_eq!(
             fail_parse(&["rcl", "eval", "infile", "--output=yamr"]),
-            "Error: Expected --output to be followed by one of json, raw, rcl, toml. See --help for usage.\n"
+            "Error: Expected --output to be followed by one of json, raw, rcl, toml, yaml-stream. See --help for usage.\n"
         );
         assert_eq!(
             fail_parse(&["rcl", "frobnicate", "infile"]),

--- a/src/fmt_json.rs
+++ b/src/fmt_json.rs
@@ -24,12 +24,12 @@ pub fn format_json(caller: Span, v: &Value) -> Result<Doc> {
 ///
 /// The formatter tracks the path in the value that we are formatting from, such
 /// that we can report the location of an error, in case an error occurs.
-struct Formatter {
+pub struct Formatter {
     /// The source location where json formatting was triggered from.
-    caller: Span,
+    pub caller: Span,
 
     /// Where we currently are in the value to be formatted.
-    path: Vec<PathElement>,
+    pub path: Vec<PathElement>,
 }
 
 impl Formatter {
@@ -106,7 +106,7 @@ impl Formatter {
         Ok(result)
     }
 
-    fn value<'a>(&mut self, v: &'a Value) -> Result<Doc<'a>> {
+    pub fn value<'a>(&mut self, v: &'a Value) -> Result<Doc<'a>> {
         let result: Doc = match v {
             Value::Null => Doc::from("null").with_markup(Markup::Keyword),
             Value::Bool(true) => Doc::from("true").with_markup(Markup::Keyword),

--- a/src/fmt_yaml_stream.rs
+++ b/src/fmt_yaml_stream.rs
@@ -1,0 +1,43 @@
+// RCL -- A reasonable configuration language.
+// Copyright 2024 Ruud van Asseldonk
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// A copy of the License has been included in the root of the repository.
+
+//! Formatter that prints list elements prefixed by `---` YAML document separators.
+
+use crate::error::{IntoError, PathElement, Result};
+use crate::fmt_json::Formatter;
+use crate::markup::Markup;
+use crate::pprint::Doc;
+use crate::runtime::Value;
+use crate::source::Span;
+
+/// Render a value in YAML stream format.
+pub fn format_yaml_stream(caller: Span, v: &Value) -> Result<Doc> {
+    let elements = match v {
+        Value::List(xs) => xs,
+        _ => {
+            return caller
+                .error("To format as YAML stream, the top-level value must be a list.")
+                .err()
+        }
+    };
+
+    let mut formatter = Formatter::new(caller);
+    let mut parts = Vec::new();
+
+    for (i, element) in elements.iter().enumerate() {
+        if !parts.is_empty() {
+            parts.push(Doc::HardBreak)
+        }
+        parts.push(Doc::str("---").with_markup(Markup::Comment));
+        parts.push(Doc::HardBreak);
+        formatter.path.push(PathElement::Index(i));
+        parts.push(formatter.value(element)?);
+        formatter.path.pop();
+    }
+
+    Ok(Doc::Concat(parts))
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,7 @@ pub mod fmt_raw;
 pub mod fmt_rcl;
 pub mod fmt_toml;
 pub mod fmt_type;
+pub mod fmt_yaml_stream;
 pub mod highlight;
 pub mod lexer;
 pub mod loader;

--- a/src/main.rs
+++ b/src/main.rs
@@ -71,6 +71,9 @@ impl App {
             OutputFormat::Raw => rcl::fmt_raw::format_raw(value_span, value)?,
             OutputFormat::Rcl => rcl::fmt_rcl::format_rcl(value),
             OutputFormat::Toml => rcl::fmt_toml::format_toml(value_span, value)?,
+            OutputFormat::YamlStream => {
+                rcl::fmt_yaml_stream::format_yaml_stream(value_span, value)?
+            }
         };
         self.print_doc_stdout(format_opts, out_doc);
         Ok(())


### PR DESCRIPTION
Add support for a new output format, `yaml-stream`. This takes a list, and outputs a stream of yaml documents, separated (prefixed by, really) `---`. The individual documents are formatted as json, which should be valid yaml. This is useful for e.g. placing multiple Kubernetes manifests in one file.