### PR TITLE
Add support for generating depfiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ simple functional programming language that resembles [Python][python] and
  * Enabling large repositories to split configuration into small reusable pieces
    that can be referenced from a single consistent entry point, in the same way
    that Nix enables this for [Nixpkgs][nixpkgs].
+ * Sharing configuration between tools that do not natively share data. For
+   example, import the same user account definitions into Terraform, Tailscale,
+   Kubernetes, and Ansible.
 
 RCL can be used through the `rcl` command-line tool that can export documents
 to json and [other formats][output]. It can also be used through a native Python

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,6 +12,9 @@ simple functional programming language that resembles [Python][python] and
  * Enabling large repositories to split configuration into small reusable pieces
    that can be referenced from a single consistent entry point, in the same way
    that Nix enables this for [Nixpkgs][nixpkgs].
+ * Sharing configuration between tools that do not natively share data. For
+   example, import the same user account definitions into Terraform, Tailscale,
+   Kubernetes, and Ansible.
 
 RCL can be used through the `rcl` command-line tool that can export documents
 to <abbr>JSON</abbr> and [other formats][output]. It can also be used through

--- a/docs/rcl.md
+++ b/docs/rcl.md
@@ -31,6 +31,11 @@ Set how output is colored. The following modes are available:
   <dd>Do not color output at all.</dd>
 </dl>
 
+The coloring applies only to stdout and stderr, it does not apply to files
+written with [`--output`][eval-output].
+
+[eval-output]: rcl_evaluate.md#-o-output-outfile
+
 ### `-C` `--directory <dir>`
 
 When loading files, consider `<dir>` to be the working directory for relative

--- a/docs/rcl_evaluate.md
+++ b/docs/rcl_evaluate.md
@@ -48,7 +48,8 @@ output format is `json`.
 Write the names of the files that were loaded during evaluation in Makefile
 syntax to the file `<depfile>`. This can be used by build systems to re-run
 `rcl` when one of the inputs changes. See also [the depfile section of the
-Ninja documentation][ninja-depfile].
+Ninja documentation][ninja-depfile]. Because the depfile includes the name of
+the dependent file, this option can only be used in combination with `--output`.
 
 [ninja-depfile]: https://ninja-build.org/manual.html#_depfile
 

--- a/docs/rcl_evaluate.md
+++ b/docs/rcl_evaluate.md
@@ -43,6 +43,15 @@ Output in the given format. The following formats are supported:
 The default output format is `rcl`. For the `je` command shorthand, the default
 output format is `json`.
 
+### `--output-depfile <depfile>`
+
+Write the names of the files that were loaded during evaluation in Makefile
+syntax to the file `<depfile>`. This can be used by build systems to re-run
+`rcl` when one of the inputs changes. See also [the depfile section of the
+Ninja documentation][ninja-depfile].
+
+[ninja-depfile]: https://ninja-build.org/manual.html#_depfile
+
 ### `-o` `--output <outfile>`
 
 Write the output to the given file instead of stdout. When [`--directory`][dir]

--- a/docs/rcl_evaluate.md
+++ b/docs/rcl_evaluate.md
@@ -56,9 +56,11 @@ the dependent file, this option can only be used in combination with `--output`.
 ### `-o` `--output <outfile>`
 
 Write the output to the given file instead of stdout. When [`--directory`][dir]
-is set, the output path is relative to that directory.
+is set, the output path is relative to that directory. [`--color`][color] does
+not apply when using `--output`.
 
-[dir]: rcl.md#-c-directory-dir
+[dir]:   rcl.md#-c-directory-dir
+[color]: rcl.md#-color-mode
 
 ### `--sandbox <mode>`
 

--- a/docs/using_ninja.md
+++ b/docs/using_ninja.md
@@ -11,7 +11,7 @@ tools.
 
 If you have just a few files, it’s not so bad to run `rcl` yourself:
 
-    rcl evaluate --format=json policies.tf.rcl --output=policies.tf.json
+    rcl evaluate --format=json policies.rcl --output=policies.json
 
 In a larger repository with many generated files, this gets tedious. It’s not
 very discoverable either. Ideally we would have one command to update all
@@ -24,7 +24,7 @@ evaluate` calls in one place. This is a big step forward, and it’s probably go
 enough. It will rebuild all files every time, but unless your configuration is
 truly massive, <abbr>RCL</abbr> is probably fast enough that it doesn’t matter.
 
-Still, it’s a bit of a shame to unnecessarily rebuild files. _Can we do better?_
+Still, it’s a bit of a shame to unnecessarily rebuild files.
 
 Also, what if _which files_ we want to generate itself depends on configuation?
 We could write the build script in Python and use [the Python module](python_bindings.md),
@@ -42,8 +42,8 @@ policies.json: policies.rcl
 ```
 
 Aside from the somewhat arcane syntax, this makefile has one big problem. If
-`policies.tf.rcl` imports an <abbr>RCL</abbr> file, say `users.rcl`, then
-Make will not rebuild `policies.tf.json` when we change `users.rcl`, because
+`policies.rcl` imports an <abbr>RCL</abbr> file, say `users.rcl`, then
+Make will not rebuild `policies.json` when we change `users.rcl`, because
 we haven’t specified the dependency in the makefile. Manually listing all
 transitive dependencies is tedious and prone to go out of date.
 
@@ -78,29 +78,29 @@ rule rcl
 Here `$in`, `$out`, and `$format` are variables. Ninja itself sets `$in` and
 `$out`, and `$format` is one that we define because it varies per target. The
 `deps = gcc` line is not required, but it makes Ninja store the depedency
-information in `.ninja_deps` and then delete the generated depfile, which is
-nice to keep the repository clean.
+information in `.ninja_deps` and then delete the generated depfile, instead of
+reading it on demand. This is nice to keep the repository clean.
 
 Next, we add a [build statement][ninja-stmt] that specifies how to build a file:
 
 ```ninja
-build policy.tf.json: rcl policy.tf.rcl
+build policies.json: rcl policies.rcl
   format = json
 ```
 
-This is enough for Ninja to work. Save the file to `build.ninja`, and then build
-`policy.tf.json`:
+This is enough for Ninja to work. Save the file to `build.ninja` and then build
+`policies.json`:
 
 ```console
 $ ninja
-[1/1] Generating policy.tf.json
+[1/1] Generating policies.json
 
 $ ninja
 ninja: no work to do.
 
 $ touch users.rcl
 $ ninja
-[1/1] Generating policy.tf.json
+[1/1] Generating policies.json
 ```
 
 [ninja-rule]: https://ninja-build.org/manual.html#_rules
@@ -110,8 +110,8 @@ $ ninja
 
 Okay, so we can write a Ninja file by hand, it’s not even that bad. But at some
 point, we’re going to end up with lots of similar build statements, and wish we
-had a way to abstract that. If only there was a language that could abstract
-away this repetition …
+had a way to abstract that. If only we had a tool that could abstract away this
+repetition …
 
 We can write a `build.rcl` that evaluates to a Ninja build file like so:
 
@@ -127,15 +127,15 @@ let ninja_prelude =
     deps = gcc
   """;
 
-let build_format = basename =>
+let build_json = basename =>
   f"""
   build {basename}.json: rcl {basename}.rcl
-    format = {format}
+    format = json
   """;
 
 // File basenames that we want to generate build rules for.
 // This is the part we need to edit when we add more files.
-let basenames_json = ["policy.tf"];
+let basenames_json = ["policies"];
 
 let sections = [
   ninja_prelude,
@@ -149,9 +149,9 @@ Now we can generate the same build file that we previously wrote by hand, and
 when we add more json target files, we only need to add one string to the list.
 By adding a `#!`-line and making the file executable, we can even record how the
 Ninja file is generated. Unfortunately, even with the `#!`-line we are back to
-multiple build steps: first `./build.rcl`, and then `ninja`. _Can we do better?_
+multiple build steps: first `./build.rcl`, and then `ninja`. Can we do better?
 
-For bootstrapping `build.ninja`, that will always need one more step. But after
+For bootstrapping `build.ninja`, that will always need a manual step. But after
 we run `./build.rcl` once, Ninja can keep `build.ninja` up to date for us. We
 just need to list it as a build target:
 
@@ -166,8 +166,71 @@ let sections = [
 ];
 ```
 
-TODO: Add example to generate from dict keys with `rcl query`.
+## Dynamic targets
+
+Now that we generate our `build.nina` from `build.rcl`, we can import
+<abbr>RCL</abbr> documents to dynamically create build tagets. For instance,
+we can leverage [`rcl query`](rcl_query.md) to build all the keys of a document
+`manifests.rcl` as separate files. We could do that as follows:
+
+```rcl
+#!/usr/bin/env -S rcl evaluate --format=raw --output=build.ninja
+
+let command = [
+  "rcl",
+  "query",
+  "--color=ansi",
+  "--format=$format",
+  "--output=$out",
+  "--output-depfile=$out.d",
+  "$in",
+  "$query",
+];
+let ninja_prelude =
+  f"""
+  rule rcl
+    description = Generating $out
+    command = {command.join(" ")}
+    depfile = $out.d
+    deps = gcc
+  """;
+
+let build_raw = (target, src) =>
+  f"""
+  build {target}: rcl {src}
+    query = input
+    format = raw
+  """;
+
+let build_json_query = (target, src, query) =>
+  f"""
+  build {target}: rcl {src}
+    format = json
+    query = {query}
+  """;
+
+let manifests = import "manifests.rcl";
+
+let sections = [
+  ninja_prelude,
+  build_raw("build.ninja", "build.rcl"),
+  for key, _ in manifests:
+  // Warning, this assumes that the key is both a valid filename
+  // and RCL expression. Currently no built-in functions exist for
+  // validating this.
+  build_json_query(f"{key}.yml", "manifests.rcl", f"input.{key}"),
+];
+
+sections.join("\n")
+```
+
+**Warning:** Generating targets dynamically is powerful, but also a sure way
+to make your build process intractable quickly! Use sparingly and with good
+judgement!
 
 ## Conclusion
 
-TODO: Summarize how powerful this is.
+RCL enables sharing configuration between systems that do not natively share
+data. To do so, you will likely need to generate files. Keeping those files up
+to date is the job of a build tool. In this chapter we have seen how to use the
+Ninja build tool, and how to use <abbr>RCL</abbr> to write Ninja build files.

--- a/docs/using_ninja.md
+++ b/docs/using_ninja.md
@@ -1,0 +1,104 @@
+# Using Ninja
+
+RCL can abstract away repetition, for example in GitHub Actions workflows and
+Kubernetes manifests. It also enables sharing configuration between systems
+that do not natively share data. For example, you can have one file to define
+users and groups, and import it into both your Tailscale configuration and into
+your Hashicorp Vault configuration. However, none of these tools natively read
+<abbr>RCL</abbr>. You still need to run `rcl` to generate the required `.yml`,
+`.tf.json`, `.json`, and `.toml` files that can be consumed by your existing
+tools.
+
+If you have just a few files, it’s not so bad to run `rcl` yourself:
+
+    rcl evaluate --format=json policies.tf.rcl --output=policies.tf.json
+
+In a larger repository with many generated files, this gets tedious. It’s not
+very discoverable either. Ideally we would have one command to update all
+generated files.
+
+## Scripting
+
+We could write a shell script or Python script, and put all those `rcl
+evaluate` calls in one place. This is a big step forward, and it’s probably good
+enough. It will rebuild all files every time, but unless your configuration is
+truly massive, <abbr>RCL</abbr> is probably fast enough that it doesn’t matter.
+
+Still, it’s a bit of a shame to unnecessarily rebuild files. _Can we do better?_
+
+## Make
+
+Updating generated files when inputs change is the role of a build tool.
+We could use [Make][gnumake] and write a makefile:
+
+```make
+policies.tf.json: policies.tf.rcl
+    rcl --format=json --output=$@ $<
+```
+
+Aside from the somewhat arcane syntax, this makefile has one big problem. If
+`policies.tf.rcl` imports an <abbr>RCL</abbr> file, say `users.rcl`, then
+Make will not rebuild `policies.tf.json` when we change `users.rcl`, because
+we haven’t specified the dependency in the makefile. Manually listing all
+transitive dependencies is tedious and prone to go out of date.
+
+[Ninja][ninja-build] is a different build tool that can solve this problem by
+reading transitive dependencies from a [depfile][depfile], and [<abbr>RCL</abbr>
+can write such a depfile][odepfile]. In the remainder of this chapter, we’ll
+explore using Ninja as the build tool.
+
+[gnumake]:     https://www.gnu.org/software/make/manual/html_node/index.html
+[ninja-build]: https://ninja-build.org/
+[depfile]:     https://ninja-build.org/manual.html#_depfile
+[odepfile]:    rcl_evaluate.md#-output-depfile-depfile
+
+## Ninja
+
+[Ninja][ninja-build] is a fast and flexible build tool, but its build files are
+low-level and intended to be _generated_, not written by hand. Let’s write one
+by hand anyway, to better understand what we are working with.
+
+In a Ninja file, we first define [a rule][ninja-rule] that specifies how
+to invoke a program. This is also where we can tell Ninja to use a
+[depfile][depfile].
+
+```ninja
+rule rcl
+  description = Generating $out
+  command = rcl eval --format=$format $in --output=$out --output-depfile=$out.d
+  depfile = $out.d
+  deps = gcc
+```
+
+Here `$in`, `$out`, and `$format` are variables. Ninja itself sets `$in` and
+`$out`, and `$format` is one that we define because it varies per target. The
+`deps = gcc` line is not required, but it makes Ninja store the depedency
+information in `.ninja_deps` and then delete the generated depfile, which is
+nice to keep the repository clean.
+
+Next, we add a [build statement][ninja-stmt] that specifies how to build a file:
+
+```ninja
+build policy.tf.json: rcl policy.tf.rcl
+  format = json
+```
+
+This is enough for Ninja to work. Save the file to `build.ninja`, and then build
+`policy.tf.json`:
+
+```console
+$ ninja
+[1/1] Generating policy.tf.json
+
+$ ninja
+ninja: no work to do.
+
+$ touch users.rcl
+$ ninja
+[1/1] Generating policy.tf.json
+```
+
+TODO: Put `--color=ansi` in there. But then `--output` should ignore it.
+
+[ninja-rule]: https://ninja-build.org/manual.html#_rules
+[ninja-stmt]: https://ninja-build.org/manual.html#_build_statements

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -20,6 +20,7 @@ nav:
       - "Tutorial": "tutorial.md"
       - "Installation": "installation.md"
       - "Syntax highlighting": "syntax_highlighting.md"
+      - "Using Ninja": "using_ninja.md"
   - "Language guide":
       - "Syntax": "syntax.md"
       - "Strings": "strings.md"

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -83,6 +83,11 @@ pub trait Filesystem {
 
     /// Load a resolved path from the filesystem.
     fn load(&self, path: PathLookup) -> Result<Document>;
+
+    /// Return `path`, but relative to the working directory, if possible.
+    ///
+    /// If the path lies outside of the working directory, return the original.
+    fn get_relative_path<'a>(&self, path: &'a Path) -> &'a Path;
 }
 
 /// A dummy filesystem impl to use during initialization.
@@ -108,6 +113,9 @@ impl Filesystem for PanicFilesystem {
     fn load(&self, _: PathLookup) -> Result<Document> {
         panic!("Should have initialized the filesystem to a real one before loading.")
     }
+    fn get_relative_path<'a>(&self, _: &'a Path) -> &'a Path {
+        panic!("Should have initialized the filesystem to a real one before resolving.")
+    }
 }
 
 /// Filesystem that fails to load anything.
@@ -127,6 +135,11 @@ impl Filesystem for VoidFilesystem {
     }
     fn load(&self, _: PathLookup) -> Result<Document> {
         Error::new("Void filesystem does not load files.").err()
+    }
+    fn get_relative_path<'a>(&self, _: &'a Path) -> &'a Path {
+        // It's okay to panic here, `get_relative_path` is only used in features
+        // that are not used by the fuzzer.
+        panic!("Void filesystem does not relativize paths.")
     }
 }
 
@@ -298,6 +311,13 @@ impl Filesystem for SandboxFilesystem {
         };
 
         Ok(doc)
+    }
+
+    fn get_relative_path<'a>(&self, path: &'a Path) -> &'a Path {
+        match path.strip_prefix(&self.workdir) {
+            Ok(p) => p,
+            Err(..) => path,
+        }
     }
 }
 
@@ -473,5 +493,29 @@ impl Loader {
                 self.load_stdin()
             }
         }
+    }
+
+    fn write_depfile_impl(&self, out_path: &Path) -> io::Result<()> {
+        use std::io::Write;
+        use std::os::unix::ffi::OsStrExt;
+        let f = std::fs::File::create(out_path)?;
+        let mut w = std::io::BufWriter::new(f);
+        w.write_all(b"out:")?;
+        for (path, _doc_id) in self.loaded_files.iter() {
+            let rel_path = self.filesystem.get_relative_path(path);
+            w.write_all(b" ")?;
+            w.write_all(rel_path.as_os_str().as_bytes())?;
+        }
+        w.write_all(b"\n")?;
+        Ok(())
+    }
+
+    pub fn write_depfile(&self, out_path: &str) -> Result<()> {
+        // The depfile output path is specified on the CLI, so we resolve it in
+        // the same way as other CLI argument paths: with `resolve_entrypoint`.
+        // This makes it work with --directory.
+        let resolved_path = self.filesystem.resolve_entrypoint(out_path)?;
+        self.write_depfile_impl(&resolved_path.path)
+            .map_err(|err| Error::new(format!("Failed to write depfile: {}.", err)).into())
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -158,7 +158,7 @@ impl App {
                 let val = self.loader.evaluate(doc, &mut env, &mut tracer)?;
 
                 if let Some(depfile_path) = eval_opts.output_depfile.as_ref() {
-                    self.loader.write_depfile(depfile_path)?;
+                    self.loader.write_depfile(&output, depfile_path)?;
                 }
 
                 // TODO: Need to get last inner span.
@@ -191,7 +191,7 @@ impl App {
                 let val_result = self.loader.evaluate(query, &mut env, &mut tracer)?;
 
                 if let Some(depfile_path) = eval_opts.output_depfile.as_ref() {
-                    self.loader.write_depfile(depfile_path)?;
+                    self.loader.write_depfile(&output, depfile_path)?;
                 }
 
                 let full_span = self.loader.get_span(query);

--- a/src/main.rs
+++ b/src/main.rs
@@ -156,6 +156,11 @@ impl App {
                 let mut env = runtime::prelude();
                 let doc = self.loader.load_cli_target(fname)?;
                 let val = self.loader.evaluate(doc, &mut env, &mut tracer)?;
+
+                if let Some(depfile_path) = eval_opts.output_depfile.as_ref() {
+                    self.loader.write_depfile(depfile_path)?;
+                }
+
                 // TODO: Need to get last inner span.
                 let full_span = self.loader.get_span(doc);
                 self.print_value(&eval_opts, &style_opts, output, full_span, &val)
@@ -184,6 +189,10 @@ impl App {
                 // clean at this point, so we can reuse it.
                 env.push("input".into(), val_input);
                 let val_result = self.loader.evaluate(query, &mut env, &mut tracer)?;
+
+                if let Some(depfile_path) = eval_opts.output_depfile.as_ref() {
+                    self.loader.write_depfile(depfile_path)?;
+                }
 
                 let full_span = self.loader.get_span(query);
                 self.print_value(&eval_opts, &style_opts, output, full_span, &val_result)

--- a/src/main.rs
+++ b/src/main.rs
@@ -60,7 +60,9 @@ impl App {
                 .opts
                 .markup
                 .unwrap_or_else(|| MarkupMode::default_for_fd(&stdout)),
-            OutputTarget::File(..) => self.opts.markup.unwrap_or(MarkupMode::None),
+            // When the output is a file, we don't want to put ANSI escape codes
+            // in the file; --output is unaffected by --color.
+            OutputTarget::File(..) => MarkupMode::None,
         };
         let cfg = pprint::Config {
             width: style_opts.width,


### PR DESCRIPTION
This adds a new option, `--output-depfile`, that can be used to write a [depfile](https://ninja-build.org/manual.html#_depfile). This can be used by Ninja to decide when an output needs to be rebuilt.

To do:

* [x] Add documentation, maybe even a tutorial, on how to generate Ninja files and use this feature.
* [ ] Find a way to test this.