### PR TITLE
Fix inline table output in toml output format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,16 +37,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
+name = "hashbrown"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
+
+[[package]]
 name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
+name = "indexmap"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "233cf39063f058ea2caae4091bf4a3ef70a653afbc026f5c4a4135d114e3c177"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
+
+[[package]]
 name = "indoc"
 version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e186cfbae8084e513daff4240b4797e342f988cecda4fb6c939150f96315fd8"
+
+[[package]]
+name = "itoa"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
 name = "jobserver"
@@ -83,6 +111,12 @@ dependencies = [
  "autocfg",
  "scopeguard",
 ]
+
+[[package]]
+name = "memchr"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
 
 [[package]]
 name = "memoffset"
@@ -124,9 +158,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.69"
+version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da"
+checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
 dependencies = [
  "unicode-ident",
 ]
@@ -202,9 +236,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.33"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
 ]
@@ -223,6 +257,8 @@ dependencies = [
  "arbitrary",
  "libfuzzer-sys",
  "rcl",
+ "serde_json",
+ "toml",
 ]
 
 [[package]]
@@ -235,10 +271,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "serde"
+version = "1.0.197"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.197"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5f09b1bd632ef549eaa9f60a1f8de742bdbc698e6cee2095fc84dde5f549ae0"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb3622f419d1296904700073ea6cc23ad690adbd66f13ea683df73298736f0c1"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "smallvec"
@@ -248,9 +330,9 @@ checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
 
 [[package]]
 name = "syn"
-version = "2.0.39"
+version = "2.0.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23e78b90f2fcf45d3e842032ce32e3f2d1545ba6636271dcbf24fa306d87be7a"
+checksum = "b699d15b36d1f02c3e7c69f8ffef53de37aefae075d8488d4ba1a7788d574a07"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -262,6 +344,40 @@ name = "target-lexicon"
 version = "0.12.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69758bda2e78f098e4ccb393021a0963bb3442eac05f135c30f61b7370bbafae"
+
+[[package]]
+name = "toml"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a9aad4a3066010876e8dcf5a8a06e70a558751117a145c6ce2b82c2e2054290"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c1b5fd4128cc8d3e0cb74d4ed9a9cc7c7284becd4df68f5f940e1ad123606f6"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
+]
 
 [[package]]
 name = "unicode-ident"
@@ -337,3 +453,12 @@ name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "winnow"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44e19b97e00a4d3db3cdb9b53c8c5f87151b5689b82cc86c2848cbdcccb2689b"
+dependencies = [
+ "memchr",
+]

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -14,6 +14,13 @@ compatibility impact will be clearly marked as such in the changelog.
 
 [semver]: https://semver.org/
 
+## Next
+
+Unreleased.
+
+ * Fix a compatibility problem in the toml output format. Improve tests and add
+   a fuzzer to rule out similar compatibility problems.
+
 ## 0.1.0
 
 Released 2024-02-26.

--- a/flake.nix
+++ b/flake.nix
@@ -22,7 +22,7 @@
           version = "0.1.0";
           pkgs = import nixpkgs { inherit system; };
 
-          python = pkgs.python3.override {
+          python = pkgs.python311.override {
             packageOverrides = self: super: {
               # This package is not in Nixpkgs, define it here.
               # I should consider upstreaming it.
@@ -111,7 +111,7 @@
             inherit version;
             name = "pyrcl";
             src = rustSources;
-            nativeBuildInputs = [pkgs.python3];
+            nativeBuildInputs = [python];
             cargoLock.lockFile = ./Cargo.lock;
             buildAndTestSubdir = "pyrcl";
             postInstall =
@@ -124,7 +124,10 @@
           rec {
             devShells.default = pkgs.mkShell {
               nativeBuildInputs = [
-                pkgs.black
+                # For consistency we could take `python.pkgs.black`, but it
+                # rebuilds half the Python universe, so instead we take the
+                # cached version that does not depend on our patched pygments.
+                pkgs.python311Packages.black
                 pkgs.maturin
                 pkgs.rustup
                 pythonEnv
@@ -163,7 +166,7 @@
 
               golden = pkgs.runCommand
                 "check-golden"
-                { buildInputs = [ pkgs.python3 ]; }
+                { buildInputs = [ python ]; }
                 ''
                 RCL_BIN=${debugBuild}/bin/rcl python3 ${goldenSources}/run.py
                 touch $out
@@ -230,7 +233,7 @@
 
               coverage = pkgs.runCommand
                 "rcl-coverage"
-                { buildInputs = [ pkgs.python3 pkgs.grcov ]; }
+                { buildInputs = [ python pkgs.grcov ]; }
                 ''
                 export bintools=${pkgs.rustc.llvmPackages.bintools-unwrapped}/bin
 

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -10,9 +10,15 @@ cargo-fuzz = true
 [dependencies]
 arbitrary = "1.3.0"
 libfuzzer-sys = "0.4"
+serde_json = "1.0.114"
 
 [dependencies.rcl]
 path = ".."
+
+[dependencies.toml]
+version = "0.8.10"
+default-features = false
+features = ["parse"]
 
 [[bin]]
 name = "cli"

--- a/golden/toml/table_in_table.test
+++ b/golden/toml/table_in_table.test
@@ -1,0 +1,15 @@
+{
+  obj = {
+    very_long_name_that_causes = {
+      The_output_to_be = "line-wrapped",
+      over_multiple_lines = true,
+    },
+  },
+}
+
+# output:
+[obj]
+very_long_name_that_causes = {
+  The_output_to_be = "line-wrapped",
+  over_multiple_lines = true,
+}

--- a/golden/toml/table_in_table.test
+++ b/golden/toml/table_in_table.test
@@ -1,6 +1,10 @@
 {
   obj = {
-    very_long_name_that_causes = {
+    // Formatting this on one line exceeds the width of the pretty-printer, it
+    // wants to break it. But it can't because TOML does not allow that. This is
+    // a regression test, in the past we did add line breaks and the output
+    // could not be parsed by Python tomllib or Rust toml crate.
+    very_long_name_that_would_cause = {
       The_output_to_be = "line-wrapped",
       over_multiple_lines = true,
     },
@@ -9,7 +13,4 @@
 
 # output:
 [obj]
-very_long_name_that_causes = {
-  The_output_to_be = "line-wrapped",
-  over_multiple_lines = true,
-}
+very_long_name_that_would_cause = { The_output_to_be = "line-wrapped", over_multiple_lines = true }

--- a/golden/toml/top_level_set_of_dict.test
+++ b/golden/toml/top_level_set_of_dict.test
@@ -1,0 +1,10 @@
+// Same shape as the list test, but this time it's a set in RCL.
+// It should still turn into a list in TOML. The values have
+// been simplified a bit.
+{
+  a = {{ x = 1 }},
+}
+
+# output:
+[[a]]
+x = 1


### PR DESCRIPTION
It turns out that toml is more restrictive about whitespace in inline tables than I thought: line breaks and trailing commas are not allowed in inline tables, even though they are allowed in arrays. Thanks @qezz for identifying this problem.

* The fix itself is simple: output spaces instead of `Doc::Sep` so the pretty-printer cannot line-break there any more, and remove the trailing comma.
* Add a golden test for the failing case.
* As a drive-by fix, sets of dicts were not formatted using the array-of-tables syntax even though lists of dicts were, make those uniform too.

But aside from the direct fix, what would have prevented this issue? And are there more cases like this one?

* Add a new fuzzer that confirms that RCL’s output can be parsed by the `toml` crate. This fuzzer immediately identified the problem fixed in this PR, and so far after ~15 minutes it hasn’t identified any other output that `toml` can’t parse.
* For the golden tests, confirm that the test expectations can be parsed by Python’s `tomllib`.
* It would be nice to also fuzz against Python’s implementation, but that is a lot harder to do efficiently, so for now I think only Rust is acceptable.
* Also fuzz the json output against `serde_json`.