### PR TITLE
Add a few built-in methods for strings

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -18,6 +18,8 @@ compatibility impact will be clearly marked as such in the changelog.
 
 Unreleased.
 
+ * Add new methods on `String`: `remove_prefix`, `remove_suffix`, `to_lowercase`,
+   `to_uppercase`.
  * Fix a compatibility problem in the toml output format. Improve tests and add
    a fuzzer to rule out similar compatibility problems.
 

--- a/docs/type_string.md
+++ b/docs/type_string.md
@@ -91,6 +91,50 @@ evaluation aborts with an error.
 "-42".parse_int()
 ```
 
+## remove_prefix
+
+    String.remove_prefix: (self: String, prefix: String) -> String
+
+Return the string without the given prefix. When `self` does not start with
+`prefix`, this aborts evaluation with an error.
+
+```rcl
+// Evaluates to "example.com".
+"https://example.com".remove_prefix("https://")
+
+// Results in an error.
+"http://example.com".remove_prefix("https://")
+
+// When an error is not desired, you can define this function:
+let remove_prefix = (str, prefix) =>
+  if str.starts_with(prefix):
+    str.remove_prefix(prefix)
+  else
+    str;
+```
+
+## remove_suffix
+
+    String.remove_suffix: (self: String, suffix: String) -> String
+
+Return the string without the given suffix. When `self` does not end with
+`suffix`, this aborts evaluation with an error.
+
+```rcl
+// Evaluates to "example".
+"example.com".remove_suffix(".com")
+
+// Results in an error.
+"example.com".remove_suffix(".org")
+
+// When an error is not desired, you can define this function:
+let remove_suffix = (str, suffix) =>
+  if str.ends_with(suffix):
+    str.remove_suffix(suffix)
+  else
+    str;
+```
+
 ## replace
 
     String.replace: (self: String, needle: String, replacement: String) -> String
@@ -151,4 +195,38 @@ Return whether the string starts with `prefix`.
 
 // Evaluates to false.
 "racecar".starts_with("ace")
+```
+
+## to_lowercase
+
+    String.to_lowercase: (self: String) -> String
+
+Convert the string to lowercase. This is implemented in terms of Rust’s
+[`to_lowercase`](https://doc.rust-lang.org/std/primitive.str.html#method.to_lowercase),
+which defines lowercase in terms of the Unicode derived core property _Lowercase_.
+Beware that Unicode can behave in unexpected ways!
+
+```rcl
+// Evaluates to "o_creat".
+"O_CREAT".to_lowercase()
+
+// Evaluates to false, İ lowercases to i followed by U+0307 Combining Dot Above.
+"İstanbul".to_lowercase() == "istanbul"
+```
+
+## to_uppercase
+
+    String.to_uppercase: (self: String) -> String
+
+Convert the string to uppercase. This is implemented in terms of Rust’s
+[`to_uppercase`](https://doc.rust-lang.org/std/primitive.str.html#method.to_uppercase),
+which defines uppercase according to the Unicode derived core property _Uppercase_.
+Beware that Unicode can behave in unexpected ways!
+
+```rcl
+// Evaluates to "O_CREAT".
+"o_creat".to_uppercase()
+
+// Evaluates to false, ß uppercases to SS instead of ẞ.
+"straße".to_uppercase() == "STRAẞE"
 ```

--- a/etc/pygments/rcl.py
+++ b/etc/pygments/rcl.py
@@ -70,6 +70,8 @@ _root_base = [
                 "keys",
                 "len",
                 "parse_int",
+                "remove_prefix",
+                "remove_suffix",
                 "replace",
                 "reverse",
                 "split",

--- a/etc/pygments/rcl.py
+++ b/etc/pygments/rcl.py
@@ -76,6 +76,8 @@ _root_base = [
                 "split_lines",
                 "starts_with",
                 "std",
+                "to_lowercase",
+                "to_uppercase",
                 "values",
             ),
             suffix=r"\b",

--- a/etc/rcl.vim/syntax/rcl.vim
+++ b/etc/rcl.vim/syntax/rcl.vim
@@ -44,7 +44,7 @@ syn region  rclFormatTriple  start='f"""' end='"""' skip='\\"\|\\{' contains=rcl
 
 " See also https://vi.stackexchange.com/questions/5966/ for why the `contains`
 " needs to end in `[]`.
-syn keyword rclBuiltin chars contains[] ends_with except fold get group_by join key_by keys len parse_int replace reverse split split_lines starts_with std values
+syn keyword rclBuiltin chars contains[] ends_with except fold get group_by join key_by keys len parse_int remove_prefix remove_suffix replace reverse split split_lines starts_with std to_lowercase to_uppercase values
 
 syn cluster rclString contains=rclStringDouble,rclStringTriple,rclFormatDouble,rclFormatTriple
 highlight link rclStringDouble rclString

--- a/fuzz/dictionary.txt
+++ b/fuzz/dictionary.txt
@@ -58,6 +58,8 @@
 "keys"
 "len"
 "parse_int"
+"remove_prefix"
+"remove_suffix"
 "replace"
 "reverse"
 "split"

--- a/fuzz/dictionary.txt
+++ b/fuzz/dictionary.txt
@@ -65,6 +65,8 @@
 "starts_with"
 "std.range"
 "std.read_file_utf8"
+"to_lowercase"
+"to_uppercase"
 "values"
 
 # Builtin types.

--- a/golden/error/std_string_remove_prefix.test
+++ b/golden/error/std_string_remove_prefix.test
@@ -1,0 +1,14 @@
+"ab".remove_prefix("c")
+
+# output:
+stdin:1:20
+  ╷
+1 │ "ab".remove_prefix("c")
+  ╵                    ^~~
+Error: Cannot remove this prefix. "ab" does not start with "c".
+
+stdin:1:19
+  ╷
+1 │ "ab".remove_prefix("c")
+  ╵                   ^
+In call to method 'String.remove_prefix'.

--- a/golden/error/std_string_remove_prefix_arg_type.test
+++ b/golden/error/std_string_remove_prefix_arg_type.test
@@ -1,0 +1,14 @@
+"ab".remove_prefix(0)
+
+# output:
+stdin:1:20
+  ╷
+1 │ "ab".remove_prefix(0)
+  ╵                    ^
+Error: Prefix must be a string.
+
+stdin:1:19
+  ╷
+1 │ "ab".remove_prefix(0)
+  ╵                   ^
+In call to method 'String.remove_prefix'.

--- a/golden/error/std_string_remove_suffix.test
+++ b/golden/error/std_string_remove_suffix.test
@@ -1,0 +1,14 @@
+"ab".remove_suffix("c")
+
+# output:
+stdin:1:20
+  ╷
+1 │ "ab".remove_suffix("c")
+  ╵                    ^~~
+Error: Cannot remove this suffix. "ab" does not end with "c".
+
+stdin:1:19
+  ╷
+1 │ "ab".remove_suffix("c")
+  ╵                   ^
+In call to method 'String.remove_suffix'.

--- a/golden/error/std_string_remove_suffix_arg_type.test
+++ b/golden/error/std_string_remove_suffix_arg_type.test
@@ -1,0 +1,14 @@
+"ab".remove_suffix(0)
+
+# output:
+stdin:1:20
+  ╷
+1 │ "ab".remove_suffix(0)
+  ╵                    ^
+Error: Suffix must be a string.
+
+stdin:1:19
+  ╷
+1 │ "ab".remove_suffix(0)
+  ╵                   ^
+In call to method 'String.remove_suffix'.

--- a/golden/rcl/string_remove_prefix.test
+++ b/golden/rcl/string_remove_prefix.test
@@ -1,0 +1,4 @@
+"ab".remove_prefix("a")
+
+# output:
+"b"

--- a/golden/rcl/string_remove_suffix.test
+++ b/golden/rcl/string_remove_suffix.test
@@ -1,0 +1,4 @@
+"ab".remove_suffix("b")
+
+# output:
+"a"

--- a/golden/rcl/string_to_lowercase.test
+++ b/golden/rcl/string_to_lowercase.test
@@ -1,0 +1,9 @@
+let strings = [
+  "O_CREAT",
+  "İstanbul",
+  "BAHNHOFSTRAẞE",
+];
+[for str in strings: str.to_lowercase()]
+
+# output:
+["o_creat", "i̇stanbul", "bahnhofstraße"]

--- a/golden/rcl/string_to_uppercase.test
+++ b/golden/rcl/string_to_uppercase.test
@@ -1,0 +1,9 @@
+let strings = [
+  "o_creat",
+  "i\u{0307}stanbul",
+  "bahnhofstraße",
+];
+[for str in strings: str.to_uppercase()]
+
+# output:
+["O_CREAT", "İSTANBUL", "BAHNHOFSTRASSE"]

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -400,6 +400,8 @@ impl<'a> Evaluator<'a> {
                     (Value::String(_), "split") => Some(&stdlib::STRING_SPLIT),
                     (Value::String(_), "split_lines") => Some(&stdlib::STRING_SPLIT_LINES),
                     (Value::String(_), "starts_with") => Some(&stdlib::STRING_STARTS_WITH),
+                    (Value::String(_), "to_lowercase") => Some(&stdlib::STRING_TO_LOWERCASE),
+                    (Value::String(_), "to_uppercase") => Some(&stdlib::STRING_TO_UPPERCASE),
 
                     (Value::Dict(_), "contains") => Some(&stdlib::DICT_CONTAINS),
                     (Value::Dict(_), "except") => Some(&stdlib::DICT_EXCEPT),

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -396,6 +396,8 @@ impl<'a> Evaluator<'a> {
                     (Value::String(_), "ends_with") => Some(&stdlib::STRING_ENDS_WITH),
                     (Value::String(_), "len") => Some(&stdlib::STRING_LEN),
                     (Value::String(_), "parse_int") => Some(&stdlib::STRING_PARSE_INT),
+                    (Value::String(_), "remove_prefix") => Some(&stdlib::STRING_REMOVE_PREFIX),
+                    (Value::String(_), "remove_suffix") => Some(&stdlib::STRING_REMOVE_SUFFIX),
                     (Value::String(_), "replace") => Some(&stdlib::STRING_REPLACE),
                     (Value::String(_), "split") => Some(&stdlib::STRING_SPLIT),
                     (Value::String(_), "split_lines") => Some(&stdlib::STRING_SPLIT_LINES),

--- a/src/highlight.rs
+++ b/src/highlight.rs
@@ -29,7 +29,8 @@ fn get_color(token: &Token, token_bytes: &[u8]) -> &'static str {
             // TODO: Only when preceded by a dot, when they are methods.
             b"chars" | b"contains" | b"ends_with" | b"enumerate" | b"except" | b"fold" | b"get"
             | b"group_by" | b"join" | b"key_by" | b"keys" | b"len" | b"parse_int" | b"replace"
-            | b"reverse" | b"split" | b"split_lines" | b"starts_with" | b"std" | b"values" => red,
+            | b"reverse" | b"split" | b"split_lines" | b"starts_with" | b"std"
+            | b"to_lowercase" | b"to_uppercase" | b"values" => red,
             _ => blue,
         },
 

--- a/src/highlight.rs
+++ b/src/highlight.rs
@@ -28,9 +28,10 @@ fn get_color(token: &Token, token_bytes: &[u8]) -> &'static str {
             // Give the builtins a different color.
             // TODO: Only when preceded by a dot, when they are methods.
             b"chars" | b"contains" | b"ends_with" | b"enumerate" | b"except" | b"fold" | b"get"
-            | b"group_by" | b"join" | b"key_by" | b"keys" | b"len" | b"parse_int" | b"replace"
-            | b"reverse" | b"split" | b"split_lines" | b"starts_with" | b"std"
-            | b"to_lowercase" | b"to_uppercase" | b"values" => red,
+            | b"group_by" | b"join" | b"key_by" | b"keys" | b"len" | b"parse_int"
+            | b"remove_prefix" | b"remove_suffix" | b"replace" | b"reverse" | b"split"
+            | b"split_lines" | b"starts_with" | b"std" | b"to_lowercase" | b"to_uppercase"
+            | b"values" => red,
             _ => blue,
         },
 

--- a/src/stdlib.rs
+++ b/src/stdlib.rs
@@ -531,6 +531,28 @@ fn builtin_string_replace(_eval: &mut Evaluator, call: MethodCall) -> Result<Val
 }
 
 builtin_method!(
+    "String.to_lowercase",
+    () -> String,
+    const STRING_TO_LOWERCASE,
+    builtin_string_to_lowercase
+);
+fn builtin_string_to_lowercase(_eval: &mut Evaluator, call: MethodCall) -> Result<Value> {
+    let string = call.receiver.expect_string();
+    Ok(Value::String(string.to_lowercase().into()))
+}
+
+builtin_method!(
+    "String.to_uppercase",
+    () -> String,
+    const STRING_TO_UPPERCASE,
+    builtin_string_to_uppercase
+);
+fn builtin_string_to_uppercase(_eval: &mut Evaluator, call: MethodCall) -> Result<Value> {
+    let string = call.receiver.expect_string();
+    Ok(Value::String(string.to_uppercase().into()))
+}
+
+builtin_method!(
     "List.fold",
     (
         seed: Any,

--- a/src/stdlib.rs
+++ b/src/stdlib.rs
@@ -531,6 +531,62 @@ fn builtin_string_replace(_eval: &mut Evaluator, call: MethodCall) -> Result<Val
 }
 
 builtin_method!(
+    "String.remove_prefix",
+    (prefix: String) -> String,
+    const STRING_REMOVE_PREFIX,
+    builtin_string_remove_prefix
+);
+fn builtin_string_remove_prefix(_eval: &mut Evaluator, call: MethodCall) -> Result<Value> {
+    let string = call.receiver.expect_string();
+    let prefix_arg = &call.call.args[0];
+    let prefix = match &prefix_arg.value {
+        Value::String(s) => s.as_ref(),
+        _ => return prefix_arg.span.error("Prefix must be a string.").err(),
+    };
+    match string.strip_prefix(prefix) {
+        Some(s) => Ok(Value::String(s.into())),
+        None => prefix_arg
+            .span
+            .error("Cannot remove this prefix.")
+            .with_body(concat! {
+                format_rcl(&call.receiver).into_owned()
+                " does not start with "
+                format_rcl(&prefix_arg.value).into_owned()
+                "."
+            })
+            .err(),
+    }
+}
+
+builtin_method!(
+    "String.remove_suffix",
+    (suffix: String) -> String,
+    const STRING_REMOVE_SUFFIX,
+    builtin_string_remove_suffix
+);
+fn builtin_string_remove_suffix(_eval: &mut Evaluator, call: MethodCall) -> Result<Value> {
+    let string = call.receiver.expect_string();
+    let suffix_arg = &call.call.args[0];
+    let suffix = match &suffix_arg.value {
+        Value::String(s) => s.as_ref(),
+        _ => return suffix_arg.span.error("Suffix must be a string.").err(),
+    };
+    match string.strip_suffix(suffix) {
+        Some(s) => Ok(Value::String(s.into())),
+        None => suffix_arg
+            .span
+            .error("Cannot remove this suffix.")
+            .with_body(concat! {
+                format_rcl(&call.receiver).into_owned()
+                " does not end with "
+                format_rcl(&suffix_arg.value).into_owned()
+                "."
+            })
+            .err(),
+    }
+}
+
+builtin_method!(
     "String.to_lowercase",
     () -> String,
     const STRING_TO_LOWERCASE,


### PR DESCRIPTION
New methods:

* `remove_prefix`
* `remove_suffix`
* `to_lowercase`
* `to_uppercase`

To do:

* [x] Ensure documentation is up to date.
* [x] Add a changelog entry.
* [x] Ensure test coverage.
* [x] Ensure the fuzzer discovers new interesting inputs.