### PR TITLE
Add a Tree-sitter grammar

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -367,6 +376,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -490,6 +528,24 @@ dependencies = [
  "serde_spanned",
  "toml_datetime",
  "winnow",
+]
+
+[[package]]
+name = "tree-sitter"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e747b1f9b7b931ed39a548c1fae149101497de3c1fc8d9e18c62c1a66c683d3d"
+dependencies = [
+ "cc",
+ "regex",
+]
+
+[[package]]
+name = "tree-sitter-rcl"
+version = "0.0.0"
+dependencies = [
+ "cc",
+ "tree-sitter",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -345,6 +345,8 @@ dependencies = [
  "rcl",
  "serde_json",
  "toml",
+ "tree-sitter",
+ "tree-sitter-rcl",
 ]
 
 [[package]]
@@ -542,7 +544,7 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-rcl"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "cc",
  "tree-sitter",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "Apache-2.0"
 unicode-width = "0.1.10"
 
 [workspace]
-members = ["fuzz", "pyrcl", "wasm"]
+members = ["fuzz", "pyrcl", "grammar/tree-sitter-rcl", "wasm"]
 
 [profile.release]
 lto = "thin"

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -24,6 +24,8 @@ Unreleased.
  * Fix a compatibility problem in the toml output format. Improve tests and add
    a fuzzer to rule out similar compatibility problems.
  * Output of `rcl format` is now colored when printing to a terminal.
+ * The repository now includes a Tree-sitter grammar. This brings syntax
+   highlighting to Helix and Neovim.
 
 ## 0.1.0
 

--- a/docs/syntax_highlighting.md
+++ b/docs/syntax_highlighting.md
@@ -6,11 +6,51 @@ Definitions for syntax coloring are available for the applications below.
 
 See <https://github.com/qezz/rcl-mode>.
 
+## Helix
+
+Helix can use [the Tree-sitter grammar](#tree-sitter). In your configuration
+directory, ensure [`languages.toml`][helix-lang] exists, and add the following
+sections:
+
+```toml
+[[language]]
+name = "rcl"
+auto-format = false
+file-types = ["rcl"]
+formatter = { command = "rcl", args = ["format", "-"] }
+indent = { tab-width = 2, unit = "  " }
+roots = ["build.rcl"]
+scope = "source.rcl"
+grammar = "rcl"
+
+[[grammar]]
+name = "rcl"
+source = { git = "https://github.com/ruuda/rcl.git", rev = "master", subpath = "grammar/tree-sitter-rcl" }
+```
+
+Furthermore, copy `grammar/tree-sitter-rcl/queries/highlights_helix.scm` into
+your Helix configuation directory at `runtime/queries/rcl/highlights.scm`.
+
+[helix-lang]: https://docs.helix-editor.com/guides/adding_languages.html
+
+## Neovim
+
+Neovim should be able to use [the Tree-sitter grammar](#tree-sitter), though I
+haven't yet looked into how.
+
 ## Pygments
 
 The directory `grammar/pygments` contains a file `rcl.py` that you can drop into
 a Pygments fork in the `pygments/lexers` directory. This lexer powers the syntax
 highlighting in this manual.
+
+## Tree-sitter
+
+The directory `grammar/tree-sitter-rcl` contains a [Tree-sitter][tree-sitter]
+grammar. It can be used by various tools, see the other sections on this page.
+For hacking on the grammar, see also [the Tree-sitter chapter](tree_sitter.md).
+
+[tree-sitter]: https://tree-sitter.github.io/tree-sitter/
 
 ## Vim
 

--- a/docs/syntax_highlighting.md
+++ b/docs/syntax_highlighting.md
@@ -35,8 +35,35 @@ your Helix configuation directory at `runtime/queries/rcl/highlights.scm`.
 
 ## Neovim
 
-Neovim should be able to use [the Tree-sitter grammar](#tree-sitter), though I
-haven't yet looked into how.
+Neovim can use [the Tree-sitter grammar](#tree-sitter) through the
+[nvim-treesitter][nvim-ts] plugin. Clone the `rcl` repository, and add the
+following to your `init.lua`:
+
+```lua
+local parser_config = require "nvim-treesitter.parsers".get_parser_configs()
+parser_config.rcl = {
+  install_info = {
+    url = "/checkout/rcl/grammar/tree-sitter-rcl",
+    files = {},
+    generate_requires_npm = false,
+    requires_generate_from_grammar = true,
+  }
+}
+```
+
+If you haven’t done so already, configure nvim-treesitter, including [enabling
+syntax highlighting][nvim-ts-highlight]. Run `:TSInstall rcl` to compile the
+parser and put the shared object on the runtimepath, and copy the highlight
+query into the `queries` subdirectory:
+
+```
+cp /checkout/rcl/grammar/tree-sitter-rcl/queries/highlights_nvim.scm /pasers-path/queries/rcl/highlights.scm
+```
+
+Then `:set filetype=rcl` on a buffer to highlight as <abbr>RCL</abbr>.
+
+[nvim-ts]: https://github.com/nvim-treesitter/nvim-treesitter
+[nvim-ts-highlight]: https://github.com/nvim-treesitter/nvim-treesitter/blob/57205313dda0ac82ac69e21d5e2a80f3297c14cc/README.md#highlight
 
 ## Pygments
 

--- a/docs/tree_sitter.md
+++ b/docs/tree_sitter.md
@@ -23,6 +23,10 @@ Then regenerate the `src/grammar.json`, and generate the other necessary files:
     cd grammar/tree-sitter-rcl
     tree-sitter generate --build
 
+Test the parse tests:
+
+    tree-sitter test
+
 Now we can try to parse a file:
 
     tree-sitter parse ../../examples/tags.rcl

--- a/docs/tree_sitter.md
+++ b/docs/tree_sitter.md
@@ -16,7 +16,7 @@ If you get Tree-sitter from the Nix development environment, make sure to set
 `CC` to a compiler provided by Nix as well. Without this, the resulting shared
 object links against a `libstdc++.so.6` that cannot be located.
 
-    export CC="$NIX_CC/bin/gcc"
+    export CC="$NIX_CC/bin/gcc" CXX="$NIX_CC/bin/g++"
 
 Then regenerate the `src/grammar.json`, and generate the other necessary files:
 

--- a/docs/tree_sitter.md
+++ b/docs/tree_sitter.md
@@ -46,7 +46,15 @@ repository, so the grammar can be used without a complex build process.
 
 [ts-user-config]: https://tree-sitter.github.io/tree-sitter/syntax-highlighting#per-user-configuration
 
-## Using the grammar
+## Queries
 
-TODO: This part is also not clear to me! Can we point Helix or Neovim at the
-directory and just expect it to work?
+The Tree-sitter queries for highlighting are editor-specific, because editors
+look for different scopes.
+
+ * [Neovim supported scopes](https://neovim.io/doc/user/treesitter#treesitter-highlight)
+ * [Helix supported scopes](https://docs.helix-editor.com/themes.html#syntax-highlighting)
+
+## Using the parser
+
+See the [syntax highlighting chapter](syntax_highlighting.md) for how to put the
+parser to use.

--- a/docs/tree_sitter.md
+++ b/docs/tree_sitter.md
@@ -41,9 +41,6 @@ Compile and test the Rust bindings:
 
     cargo test
 
-Even though `src/grammar.json` is a generated file, we commit it to the
-repository, so the grammar can be used without a complex build process.
-
 [ts-user-config]: https://tree-sitter.github.io/tree-sitter/syntax-highlighting#per-user-configuration
 
 ## Queries

--- a/docs/tree_sitter.md
+++ b/docs/tree_sitter.md
@@ -31,12 +31,19 @@ Now we can try to parse a file:
 
     tree-sitter parse ../../examples/tags.rcl
 
+Even highlight it, after [adding the `rcl/grammar` directory to your Tree-sitter
+per-user configuration][ts-user-config].
+
+    tree-sitter highlight ../../examples/tags.rcl
+
 Compile and test the Rust bindings:
 
     cargo test
 
 Even though `src/grammar.json` is a generated file, we commit it to the
 repository, so the grammar can be used without a complex build process.
+
+[ts-user-config]: https://tree-sitter.github.io/tree-sitter/syntax-highlighting#per-user-configuration
 
 ## Using the grammar
 

--- a/docs/tree_sitter.md
+++ b/docs/tree_sitter.md
@@ -1,7 +1,8 @@
 # Tree-sitter
 
 The repository includes a [Tree-sitter][tree-sitter] grammar at
-`grammar/tree-sitter-rcl`.
+`grammar/tree-sitter-rcl`. This chapter is about hacking on the grammar.
+For editors that support this grammar, see [the syntax highlighting chapter](syntax_highlighting.md).
 
 [tree-sitter]: https://tree-sitter.github.io/tree-sitter/
 

--- a/docs/tree_sitter.md
+++ b/docs/tree_sitter.md
@@ -51,8 +51,9 @@ repository, so the grammar can be used without a complex build process.
 The Tree-sitter queries for highlighting are editor-specific, because editors
 look for different scopes.
 
- * [Neovim supported scopes](https://neovim.io/doc/user/treesitter#treesitter-highlight)
  * [Helix supported scopes](https://docs.helix-editor.com/themes.html#syntax-highlighting)
+ * [Neovim supported scopes](https://neovim.io/doc/user/treesitter#treesitter-highlight)
+ * [Tree-sitter <abbr>CLI</abbr> supported scopes](https://github.com/tree-sitter/tree-sitter/blob/v0.22.1/highlight/README.md)
 
 ## Using the parser
 

--- a/docs/tree_sitter.md
+++ b/docs/tree_sitter.md
@@ -1,0 +1,40 @@
+# Tree-sitter
+
+The repository includes a [Tree-sitter][tree-sitter] grammar at
+`grammar/tree-sitter-rcl`.
+
+[tree-sitter]: https://tree-sitter.github.io/tree-sitter/
+
+## Editing the grammar
+
+Tree-sitter grammars are written in Javascript. Regenerating the parser involves
+executing Javascript outside of a browser, but fortunately no <abbr>NPM</abbr>
+packages or `node_modules` are involved. The Nix development environment
+includes all the tools that are needed.
+
+If you get Tree-sitter from the Nix development environment, make sure to set
+`CC` to a compiler provided by Nix as well. Without this, the resulting shared
+object links against a `libstdc++.so.6` that cannot be located.
+
+    export CC="$NIX_CC/bin/gcc"
+
+Then regenerate the `src/grammar.json`, and generate the other necessary files:
+
+    cd grammar/tree-sitter-rcl
+    tree-sitter generate --build
+
+Now we can try to parse a file:
+
+    tree-sitter parse ../../examples/tags.rcl
+
+Compile and test the Rust bindings:
+
+    cargo test
+
+Even though `src/grammar.json` is a generated file, we commit it to the
+repository, so the grammar can be used without a complex build process.
+
+## Using the grammar
+
+TODO: This part is also not clear to me! Can we point Helix or Neovim at the
+directory and just expect it to work?

--- a/flake.nix
+++ b/flake.nix
@@ -89,9 +89,31 @@
             "Cargo.toml"
           ];
 
+          treeSitterSources = pkgs.lib.sourceFilesBySuffices ./grammar/tree-sitter-rcl [
+            ".json"
+            "Cargo.toml"
+            "grammar.js"
+          ];
+
           pythonSources = pkgs.lib.sourceFilesBySuffices ./. [ ".py" ".pyi" ];
 
           goldenSources = ./golden;
+
+          treeSitterRcl = pkgs.stdenv.mkDerivation {
+            pname = "tree-sitter-rcl";
+            inherit version;
+            src = treeSitterSources;
+            nativeBuildInputs = [ pkgs.nodejs pkgs.tree-sitter ];
+            buildPhase = "tree-sitter generate";
+            installPhase =
+            ''
+            mkdir -p $out/bindings
+            mkdir -p $out
+            cp -r bindings/rust $out/bindings
+            cp -r src $out
+            cp Cargo.toml $out
+            '';
+          };
 
           rcl = pkgs.rustPlatform.buildRustPackage rec {
             inherit name version;
@@ -278,7 +300,7 @@
             };
 
             packages = {
-              inherit rcl pyrcl;
+              inherit rcl pyrcl treeSitterRcl;
 
               default = rcl;
               wasm = rcl-wasm;

--- a/flake.nix
+++ b/flake.nix
@@ -169,6 +169,7 @@
         in
           rec {
             devShells.default = pkgs.mkShell {
+              name = "rcl";
               nativeBuildInputs = [
                 # For consistency we could take `python.pkgs.black`, but it
                 # rebuilds half the Python universe, so instead we take the

--- a/flake.nix
+++ b/flake.nix
@@ -175,9 +175,11 @@
                 # cached version that does not depend on our patched pygments.
                 pkgs.python311Packages.black
                 pkgs.binaryen
-                pkgs.wasm-bindgen-cli
                 pkgs.maturin
+                pkgs.nodejs  # Required for tree-sitter.
                 pkgs.rustup
+                pkgs.tree-sitter
+                pkgs.wasm-bindgen-cli
                 pythonEnv
               ];
 

--- a/flake.nix
+++ b/flake.nix
@@ -91,6 +91,7 @@
 
           treeSitterSources = pkgs.lib.sourceFilesBySuffices ./grammar/tree-sitter-rcl [
             ".json"
+            ".txt"
             "Cargo.toml"
             "grammar.js"
           ];
@@ -104,15 +105,26 @@
             inherit version;
             src = treeSitterSources;
             nativeBuildInputs = [ pkgs.nodejs pkgs.tree-sitter ];
+            doCheck = true;
             buildPhase = "tree-sitter generate";
+            checkPhase =
+              ''
+              # Tree sitter wants to write to ~/.config by default, but that
+              # does not exist in the sandbox. Give it a directory to write to.
+              mkdir tree-sitter-home
+              export TREE_SITTER_DIR=tree-sitter-home
+              export TREE_SITTER_LIBDIR=tree-sitter-home
+              tree-sitter generate --build
+              tree-sitter test
+              '';
             installPhase =
-            ''
-            mkdir -p $out/bindings
-            mkdir -p $out
-            cp -r bindings/rust $out/bindings
-            cp -r src $out
-            cp Cargo.toml $out
-            '';
+              ''
+              mkdir -p $out/bindings
+              mkdir -p $out
+              cp -r bindings/rust $out/bindings
+              cp -r src $out
+              cp Cargo.toml $out
+              '';
           };
 
           rcl = pkgs.rustPlatform.buildRustPackage rec {

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -10,10 +10,10 @@ cargo-fuzz = true
 [dependencies]
 arbitrary = "1.3.0"
 libfuzzer-sys = "0.4"
+rcl = { path = ".." }
 serde_json = "1.0.114"
-
-[dependencies.rcl]
-path = ".."
+tree-sitter = "0.20.10"
+tree-sitter-rcl = { path = "../grammar/tree-sitter-rcl" }
 
 [dependencies.toml]
 version = "0.8.10"
@@ -47,5 +47,11 @@ doc = false
 [[bin]]
 name = "string_len"
 path = "fuzz_targets/string_len.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "tree_sitter"
+path = "fuzz_targets/tree_sitter.rs"
 test = false
 doc = false

--- a/fuzz/fuzz_targets/tree_sitter.rs
+++ b/fuzz/fuzz_targets/tree_sitter.rs
@@ -1,0 +1,49 @@
+// RCL -- A reasonable configuration language.
+// Copyright 2024 Ruud van Asseldonk
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// A copy of the License has been included in the root of the repository.
+
+//! A fuzzer for the Tree-sitter grammar.
+//!
+//! This fuzzer runs the same input through both the Tree-sitter parser and
+//! RCL's parser, and then checks that they agree. Right now we only check
+//! that they agree about the input validity, but we should do a deep comparison
+//! of the parse tree. TODO: Implement that comparison.
+
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use rcl::loader::Loader;
+
+fuzz_target!(|input: &str| {
+    // Step 1: Parse with Tree-sitter.
+    let mut parser = tree_sitter::Parser::new();
+    parser
+        .set_language(tree_sitter_rcl::language())
+        .expect("Failed to load grammar.");
+    let ts_tree = parser
+        .parse(input, None)
+        .expect("Tree-sitter produces a tree when configured correctly.");
+
+    // Step 2: Parse with RCL.
+    let mut loader = Loader::new();
+    let id = loader.load_string(input.to_string());
+    let rcl_tree = loader.get_cst(id);
+
+    // Step 3: Compare.
+    // It would be nice to do a deep comparison, but as a first step, when the
+    // grammar is still in progress, we can check that RCL can parse iff TS can
+    // parse. TODO: extend to deeper comparison.
+    match rcl_tree {
+        Ok(..) => assert!(
+            !ts_tree.root_node().has_error(),
+            "RCL accepted but Tree-sitter rejected.",
+        ),
+        Err(..) => assert!(
+            ts_tree.root_node().has_error(),
+            "RCL rejected but Tree-sitter accepted.",
+        ),
+    }
+});

--- a/fuzz/fuzz_targets/tree_sitter.rs
+++ b/fuzz/fuzz_targets/tree_sitter.rs
@@ -18,18 +18,10 @@ use libfuzzer_sys::fuzz_target;
 use rcl::loader::Loader;
 
 fuzz_target!(|input: &str| {
-    // There are some inputs that Tree-sitter does not parse, but they are silly
-    // edge cases that we don't really care about where if you had them in your
-    // source code, you have worse problems than Tree-sitter inserting an error
-    // node. There are also cases with code points outside of ASCII that we
-    // should care about in some places, but it's hard without parsing to say
-    // if they are in an allowed or non-allowed place. So for now, we only fuzz
-    // ASCII inputs.
-    if input
-        .as_bytes()
-        .iter()
-        .any(|b| matches!(b, 0 | 0x0c | 0x80..=0xff))
-    {
+    // Tree-sitter does not handle null bytes, but if you have null bytes in
+    // your input, you have worse problems than your syntax highlighting being
+    // off, so we don't care much about such inputs.
+    if input.as_bytes().contains(&0) {
         return;
     }
 

--- a/fuzz/fuzz_targets/tree_sitter.rs
+++ b/fuzz/fuzz_targets/tree_sitter.rs
@@ -22,7 +22,11 @@ fuzz_target!(|input: &str| {
     // edge cases that we don't really care about where if you had them in your
     // source code, you have worse problems than Tree-sitter inserting an error
     // node.
-    if input.contains('\0') || input.contains('\x0c') {
+    if input
+        .as_bytes()
+        .iter()
+        .any(|b| matches!(b, 0 | 0x0c | 0xff))
+    {
         return;
     }
 

--- a/fuzz/fuzz_targets/tree_sitter.rs
+++ b/fuzz/fuzz_targets/tree_sitter.rs
@@ -18,6 +18,14 @@ use libfuzzer_sys::fuzz_target;
 use rcl::loader::Loader;
 
 fuzz_target!(|input: &str| {
+    // There are some inputs that Tree-sitter does not parse, but they are silly
+    // edge cases that we don't really care about where if you had them in your
+    // source code, you have worse problems than Tree-sitter inserting an error
+    // node.
+    if input.contains('\0') || input.contains('\x0c') {
+        return;
+    }
+
     // Step 1: Parse with Tree-sitter.
     let mut parser = tree_sitter::Parser::new();
     parser

--- a/fuzz/fuzz_targets/tree_sitter.rs
+++ b/fuzz/fuzz_targets/tree_sitter.rs
@@ -21,11 +21,14 @@ fuzz_target!(|input: &str| {
     // There are some inputs that Tree-sitter does not parse, but they are silly
     // edge cases that we don't really care about where if you had them in your
     // source code, you have worse problems than Tree-sitter inserting an error
-    // node.
+    // node. There are also cases with code points outside of ASCII that we
+    // should care about in some places, but it's hard without parsing to say
+    // if they are in an allowed or non-allowed place. So for now, we only fuzz
+    // ASCII inputs.
     if input
         .as_bytes()
         .iter()
-        .any(|b| matches!(b, 0 | 0x0c | 0xff))
+        .any(|b| matches!(b, 0 | 0x0c | 0x80..=0xff))
     {
         return;
     }

--- a/grammar/bison/grammar.y
+++ b/grammar/bison/grammar.y
@@ -144,7 +144,4 @@ types
   | type_expr ',' type_expr
   ;
 
-type_term
-  : IDENT
-  | STRING
-  ;
+type_term: IDENT;

--- a/grammar/tree-sitter-rcl/.gitignore
+++ b/grammar/tree-sitter-rcl/.gitignore
@@ -1,0 +1,10 @@
+# Projects files that `tree-sitter generate` generates, but I really don't care
+# about, because I want to minimize the amount of javascript that executes
+# outside of a browser please.
+/binding.gyp
+/bindings/node/
+/package.json
+
+# Generated files that are intermediate build artifacts, and not needed to use
+# the grammar.
+/src/

--- a/grammar/tree-sitter-rcl/.gitignore
+++ b/grammar/tree-sitter-rcl/.gitignore
@@ -1,9 +1,9 @@
 # Projects files that `tree-sitter generate` generates, but I really don't care
 # about, because I want to minimize the amount of javascript that executes
-# outside of a browser please.
+# outside of a browser please. We do need package.json for the file type
+# metadata and for `tree-sitter highlight` to work.
 /binding.gyp
 /bindings/node/
-/package.json
 
 # Generated files that are intermediate build artifacts, and not needed to use
 # the grammar.

--- a/grammar/tree-sitter-rcl/Cargo.toml
+++ b/grammar/tree-sitter-rcl/Cargo.toml
@@ -3,7 +3,7 @@ name = "tree-sitter-rcl"
 description = "RCL grammar for the tree-sitter parsing library"
 keywords = ["incremental", "parsing", "rcl"]
 categories = ["parsing", "text-editors"]
-version = "0.0.0"
+version = "0.1.0"
 authors = ["Ruud van Asseldonk <dev@veniogames.com>"]
 edition = "2021"
 license = "Apache-2.0"
@@ -20,7 +20,7 @@ include = [
 path = "bindings/rust/lib.rs"
 
 [dependencies]
-tree-sitter = "~0.20.10"
+tree-sitter = "0.20.10"
 
 [build-dependencies]
 cc = "1.0"

--- a/grammar/tree-sitter-rcl/Cargo.toml
+++ b/grammar/tree-sitter-rcl/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "tree-sitter-rcl"
+description = "RCL grammar for the tree-sitter parsing library"
+keywords = ["incremental", "parsing", "rcl"]
+categories = ["parsing", "text-editors"]
+version = "0.0.0"
+authors = ["Ruud van Asseldonk <dev@veniogames.com>"]
+edition = "2021"
+license = "Apache-2.0"
+
+build = "bindings/rust/build.rs"
+include = [
+  "bindings/rust/*",
+  "grammar.js",
+  "queries/*",
+  "src/*",
+]
+
+[lib]
+path = "bindings/rust/lib.rs"
+
+[dependencies]
+tree-sitter = "~0.20.10"
+
+[build-dependencies]
+cc = "1.0"

--- a/grammar/tree-sitter-rcl/bindings/rust/build.rs
+++ b/grammar/tree-sitter-rcl/bindings/rust/build.rs
@@ -1,0 +1,40 @@
+fn main() {
+    let src_dir = std::path::Path::new("src");
+
+    let mut c_config = cc::Build::new();
+    c_config.include(&src_dir);
+    c_config
+        .flag_if_supported("-Wno-unused-parameter")
+        .flag_if_supported("-Wno-unused-but-set-variable")
+        .flag_if_supported("-Wno-trigraphs");
+    let parser_path = src_dir.join("parser.c");
+    c_config.file(&parser_path);
+
+    // If your language uses an external scanner written in C,
+    // then include this block of code:
+
+    /*
+    let scanner_path = src_dir.join("scanner.c");
+    c_config.file(&scanner_path);
+    println!("cargo:rerun-if-changed={}", scanner_path.to_str().unwrap());
+    */
+
+    c_config.compile("parser");
+    println!("cargo:rerun-if-changed={}", parser_path.to_str().unwrap());
+
+    // If your language uses an external scanner written in C++,
+    // then include this block of code:
+
+    /*
+    let mut cpp_config = cc::Build::new();
+    cpp_config.cpp(true);
+    cpp_config.include(&src_dir);
+    cpp_config
+        .flag_if_supported("-Wno-unused-parameter")
+        .flag_if_supported("-Wno-unused-but-set-variable");
+    let scanner_path = src_dir.join("scanner.cc");
+    cpp_config.file(&scanner_path);
+    cpp_config.compile("scanner");
+    println!("cargo:rerun-if-changed={}", scanner_path.to_str().unwrap());
+    */
+}

--- a/grammar/tree-sitter-rcl/bindings/rust/build.rs
+++ b/grammar/tree-sitter-rcl/bindings/rust/build.rs
@@ -1,40 +1,13 @@
 fn main() {
     let src_dir = std::path::Path::new("src");
-
     let mut c_config = cc::Build::new();
-    c_config.include(&src_dir);
+    c_config.include(src_dir);
     c_config
         .flag_if_supported("-Wno-unused-parameter")
         .flag_if_supported("-Wno-unused-but-set-variable")
         .flag_if_supported("-Wno-trigraphs");
     let parser_path = src_dir.join("parser.c");
     c_config.file(&parser_path);
-
-    // If your language uses an external scanner written in C,
-    // then include this block of code:
-
-    /*
-    let scanner_path = src_dir.join("scanner.c");
-    c_config.file(&scanner_path);
-    println!("cargo:rerun-if-changed={}", scanner_path.to_str().unwrap());
-    */
-
     c_config.compile("parser");
     println!("cargo:rerun-if-changed={}", parser_path.to_str().unwrap());
-
-    // If your language uses an external scanner written in C++,
-    // then include this block of code:
-
-    /*
-    let mut cpp_config = cc::Build::new();
-    cpp_config.cpp(true);
-    cpp_config.include(&src_dir);
-    cpp_config
-        .flag_if_supported("-Wno-unused-parameter")
-        .flag_if_supported("-Wno-unused-but-set-variable");
-    let scanner_path = src_dir.join("scanner.cc");
-    cpp_config.file(&scanner_path);
-    cpp_config.compile("scanner");
-    println!("cargo:rerun-if-changed={}", scanner_path.to_str().unwrap());
-    */
 }

--- a/grammar/tree-sitter-rcl/bindings/rust/lib.rs
+++ b/grammar/tree-sitter-rcl/bindings/rust/lib.rs
@@ -35,7 +35,7 @@ pub const NODE_TYPES: &'static str = include_str!("../../src/node-types.json");
 
 // Uncomment these to include any queries that this grammar contains
 
-// pub const HIGHLIGHTS_QUERY: &'static str = include_str!("../../queries/highlights.scm");
+pub const HIGHLIGHTS_QUERY: &'static str = include_str!("../../queries/highlights.scm");
 // pub const INJECTIONS_QUERY: &'static str = include_str!("../../queries/injections.scm");
 // pub const LOCALS_QUERY: &'static str = include_str!("../../queries/locals.scm");
 // pub const TAGS_QUERY: &'static str = include_str!("../../queries/tags.scm");

--- a/grammar/tree-sitter-rcl/bindings/rust/lib.rs
+++ b/grammar/tree-sitter-rcl/bindings/rust/lib.rs
@@ -31,12 +31,11 @@ pub fn language() -> Language {
 /// The content of the [`node-types.json`][] file for this grammar.
 ///
 /// [`node-types.json`]: https://tree-sitter.github.io/tree-sitter/using-parsers#static-node-types
-pub const NODE_TYPES: &'static str = include_str!("../../src/node-types.json");
+pub const NODE_TYPES: &str = include_str!("../../src/node-types.json");
 
 // Uncomment these to include any queries that this grammar contains
 
-pub const HIGHLIGHTS_QUERY: &'static str = include_str!("../../queries/highlights.scm");
-// pub const INJECTIONS_QUERY: &'static str = include_str!("../../queries/injections.scm");
+pub const HIGHLIGHTS_QUERY: &str = include_str!("../../queries/highlights.scm");
 // pub const LOCALS_QUERY: &'static str = include_str!("../../queries/locals.scm");
 // pub const TAGS_QUERY: &'static str = include_str!("../../queries/tags.scm");
 

--- a/grammar/tree-sitter-rcl/bindings/rust/lib.rs
+++ b/grammar/tree-sitter-rcl/bindings/rust/lib.rs
@@ -1,0 +1,52 @@
+//! This crate provides RCL language support for the [tree-sitter][] parsing library.
+//!
+//! Typically, you will use the [language][language func] function to add this language to a
+//! tree-sitter [Parser][], and then use the parser to parse some code:
+//!
+//! ```
+//! let code = "";
+//! let mut parser = tree_sitter::Parser::new();
+//! parser.set_language(tree_sitter_rcl::language()).expect("Error loading RCL grammar");
+//! let tree = parser.parse(code, None).unwrap();
+//! ```
+//!
+//! [Language]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Language.html
+//! [language func]: fn.language.html
+//! [Parser]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Parser.html
+//! [tree-sitter]: https://tree-sitter.github.io/
+
+use tree_sitter::Language;
+
+extern "C" {
+    fn tree_sitter_rcl() -> Language;
+}
+
+/// Get the tree-sitter [Language][] for this grammar.
+///
+/// [Language]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Language.html
+pub fn language() -> Language {
+    unsafe { tree_sitter_rcl() }
+}
+
+/// The content of the [`node-types.json`][] file for this grammar.
+///
+/// [`node-types.json`]: https://tree-sitter.github.io/tree-sitter/using-parsers#static-node-types
+pub const NODE_TYPES: &'static str = include_str!("../../src/node-types.json");
+
+// Uncomment these to include any queries that this grammar contains
+
+// pub const HIGHLIGHTS_QUERY: &'static str = include_str!("../../queries/highlights.scm");
+// pub const INJECTIONS_QUERY: &'static str = include_str!("../../queries/injections.scm");
+// pub const LOCALS_QUERY: &'static str = include_str!("../../queries/locals.scm");
+// pub const TAGS_QUERY: &'static str = include_str!("../../queries/tags.scm");
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_can_load_grammar() {
+        let mut parser = tree_sitter::Parser::new();
+        parser
+            .set_language(super::language())
+            .expect("Error loading RCL language");
+    }
+}

--- a/grammar/tree-sitter-rcl/grammar.js
+++ b/grammar/tree-sitter-rcl/grammar.js
@@ -13,6 +13,10 @@ module.exports = grammar({
 
   word: $ => $.ident,
 
+  conflicts: $ => [
+    [ $.function_args, $._expr_term ],
+  ],
+
   rules: {
     source_file: $ => seq(repeat($._prefix), $._expr),
 
@@ -73,9 +77,7 @@ module.exports = grammar({
     function_args: $ => choice(
       $.ident,
       seq("(", ")"),
-      // The precedence here must be higher than of a `(ident)`-expression to
-      // resolve the ambiguity.
-      prec(2, seq("(", $.ident, repeat(seq(",", $.ident)), optional(","), ")")),
+      seq("(", $.ident, repeat(seq(",", $.ident)), optional(","), ")"),
     ),
 
     expr_unop: $ => choice(
@@ -122,15 +124,14 @@ module.exports = grammar({
     _expr_term: $ => choice(
       $.expr_term_braces,
       $.expr_term_brackets,
-      // The precedence here is lower than of function args.
-      prec(1, $.expr_term_parens),
+      $.expr_term_parens,
       $.string,
       $.number,
       $.ident,
     ),
     expr_term_braces:   $ => seq("{", optional($._seqs), "}"),
     expr_term_brackets: $ => seq("[", optional($._seqs), "]"),
-    expr_term_parens:   $ => seq("(", optional($._seqs), ")"),
+    expr_term_parens:   $ => seq("(", $._expr, ")"),
 
     _stmt: $ => seq(choice($.stmt_let)),
     stmt_let: $ => seq(

--- a/grammar/tree-sitter-rcl/grammar.js
+++ b/grammar/tree-sitter-rcl/grammar.js
@@ -123,6 +123,7 @@ module.exports = grammar({
     function_args: $ => choice(
       $.ident,
       seq("(", ")"),
+      seq("(", repeat($._prefix), ")"),
       seq("(", $.ident, repeat(seq(",", $.ident)), optional(","), ")"),
     ),
 

--- a/grammar/tree-sitter-rcl/grammar.js
+++ b/grammar/tree-sitter-rcl/grammar.js
@@ -16,7 +16,7 @@ module.exports = grammar({
     // A blank is whitespace with two or more newlines. This token is distinct
     // from the regular whitespace, that Tree-sitter by default allows anywhere.
     blank: $ => /[ \t\r\f]*\n[ \t\r\f]*\n[ \t\r\n\f]*/,
-    comment: $ => seq("//", /[^\n]*\n/),
+    comment: $ => /\/\/[^\n]*\n/,
     _prefix: $ => choice($.blank, $.comment),
 
     ident: $ => /[_A-Za-z][-_A-Za-z0-9]*/,

--- a/grammar/tree-sitter-rcl/grammar.js
+++ b/grammar/tree-sitter-rcl/grammar.js
@@ -27,13 +27,23 @@ module.exports = grammar({
     // TODO: Implement the custom lexer to handle string literals.
     string: $ => /"[^"]*"/,
 
+    unop: $ => choice("not", "-"),
+
     _expr: $ => choice(
       $.expr_stmt,
       $._expr_op,
     ),
     expr_stmt: $ => seq($._stmt, ";", repeat($._prefix), $._expr),
 
-    _expr_op: $ => choice($._expr_not_op),
+    _expr_op: $ => choice(
+      $.expr_unop,
+      $._expr_not_op,
+    ),
+
+    expr_unop: $ => choice(
+      seq($.unop, $._expr_not_op),
+      seq($.unop, $.expr_unop),
+    ),
 
     _expr_not_op: $ => choice(
       $._expr_term,

--- a/grammar/tree-sitter-rcl/grammar.js
+++ b/grammar/tree-sitter-rcl/grammar.js
@@ -94,6 +94,9 @@ module.exports = grammar({
     num_hexadecimal: $ => /0x[0-9a-fA-F_]*/,
     num_decimal: $ => /(0|[1-9][0-9_]*)(\.[0-9][0-9_]*)?([eE][-+]?[0-9][0-9_]*)?/,
 
+    "null": $ => "null",
+    bool: $ => choice("true", "false"),
+
     unop_keyword: $ => choice("not"),
     binop_keyword: $ => choice("and", "or"),
 
@@ -190,6 +193,8 @@ module.exports = grammar({
       $.string,
       $.number,
       $.ident,
+      $.bool,
+      $["null"],
     ),
     expr_term_braces:   $ => seq("{", optional($._seqs), "}"),
     expr_term_brackets: $ => seq("[", optional($._seqs), "]"),

--- a/grammar/tree-sitter-rcl/grammar.js
+++ b/grammar/tree-sitter-rcl/grammar.js
@@ -8,23 +8,77 @@
 module.exports = grammar({
   name: "rcl",
 
-  rules: {
-    source_file: $ => $._prefixed_expr,
+  word: $ => $.ident,
 
-    // A blank is whitespace with two or more newlines.
-    // Space allows arbitrary newlines, but they are not preserved in the CST.
+  rules: {
+    source_file: $ => seq(repeat($._prefix), $._expr),
+
+    // A blank is whitespace with two or more newlines. This token is distinct
+    // from the regular whitespace, that Tree-sitter by default allows anywhere.
     blank: $ => /[ \t\r\f]*\n[ \t\r\f]*\n[ \t\r\n\f]*/,
-    _space: $ => /[ \t\r\n\f]+/,
     comment: $ => seq("//", /[^\n]*\n/),
-    _prefix: $ => choice($.blank, $.comment, $._space),
+    _prefix: $ => choice($.blank, $.comment),
 
     ident: $ => /[_A-Za-z][-_A-Za-z0-9]*/,
 
-    _prefixed_expr: $ => seq(repeat($._prefix), $._expr),
-    _expr: $ => choice($.expr_stmt),
-    expr_stmt: $ => seq($._stmt, $._space, ";", $._prefixed_expr),
+    // TODO: Implement the custom lexer to handle string literals.
+    string: $ => /"[^"]*"/,
 
-    _stmt: $ => choice($.stmt_let),
-    stmt_let: $ => seq("let", $._space, $.ident, $._space, "=", $._prefixed_expr),
+    _expr: $ => choice($.expr_stmt),
+    expr_stmt: $ => seq($._stmt, ";", repeat($._prefix), $._expr),
+
+    _expr_op: $ => choice($._expr_not_op),
+
+    _expr_not_op: $ => choice(
+      $._expr_term,
+      // TODO: Add call, add index.
+      $.expr_field,
+    ),
+    expr_field: $ => seq(
+      field("inner", $._expr_not_op),
+      ".",
+      field("field", $.ident),
+    ),
+
+    _expr_term: $ => choice(
+      $.expr_term_braces,
+      $.expr_term_brackets,
+      $.expr_term_parens,
+      $.string,
+      $.ident,
+    ),
+    expr_term_braces:   $ => seq("{", optional($._seqs), "}"),
+    expr_term_brackets: $ => seq("[", optional($._seqs), "]"),
+    expr_term_parens:   $ => seq("(", optional($._seqs), ")"),
+
+    _stmt: $ => seq(choice($.stmt_let)),
+    stmt_let: $ => seq(
+      "let",
+      field("ident", $.ident),
+      "=",
+      repeat($._prefix),
+      field("value", $._expr),
+    ),
+
+    // One or more `seq`s with an optional trailing comma. The use site has to
+    // wrap it in `optional` as Tree-sitter does not support rules that match
+    // the empty string.
+    _seqs: $ => seq(
+      repeat1(seq(repeat($._prefix), $._seq, ",")),
+      optional(seq(",", repeat($._prefix))),
+    ),
+
+    _seq: $ => seq(
+      $._expr_op,
+      seq($._expr_op, ":", $._expr),
+      seq($.ident, "=", $._expr),
+      // TODO: I need to allow a prefix here. Will the fuzzer find it?
+      seq($._stmt, ";", $._seq),
+      seq("for", $._idents, "in", $._expr, ":", $._seq),
+      seq("if", $._expr, ":", $._seq),
+    ),
+
+    // One or more identifiers separated by comma, no trailing comma allowed.
+    _idents: $=> seq($.ident, repeat(seq(",", $.ident))),
   }
 });

--- a/grammar/tree-sitter-rcl/grammar.js
+++ b/grammar/tree-sitter-rcl/grammar.js
@@ -105,11 +105,14 @@ module.exports = grammar({
     expr_stmt: $ => seq($._stmt, ";", repeat($._prefix), $._expr),
 
     _expr_op: $ => choice(
+      $.expr_import,
       $.expr_function,
       $.expr_unop,
       $.expr_binop,
       $._expr_not_op,
     ),
+
+    expr_import: $ => seq("import", $._expr),
 
     expr_function: $ => seq(
       field("args", $.function_args),

--- a/grammar/tree-sitter-rcl/grammar.js
+++ b/grammar/tree-sitter-rcl/grammar.js
@@ -42,7 +42,7 @@ module.exports = grammar({
     ),
     string_triple: $ => seq(
       "\"\"\"",
-      repeat(choice($._string_char, $.string_escape)),
+      repeat(choice($._string_char, $.string_escape, "\"")),
       "\"\"\"",
     ),
 

--- a/grammar/tree-sitter-rcl/grammar.js
+++ b/grammar/tree-sitter-rcl/grammar.js
@@ -28,8 +28,23 @@ module.exports = grammar({
 
     ident: $ => /[_A-Za-z][-_A-Za-z0-9]*/,
 
-    // TODO: Implement the custom lexer to handle string literals.
-    string: $ => /"[^"]*"/,
+    _string: $ => choice($.string_double, $.string_triple),
+    string_escape: $ => choice(
+      /\\./,
+      /\\u[0-9a-fA-F]{4}/,
+      seq("\\u{", /[0-9a-fA-F]*/, "}"),
+    ),
+    _string_char: $ => /[^\\"]/,
+    string_double: $ => seq(
+      "\"",
+      repeat(choice($._string_char, $.string_escape)),
+      "\"",
+    ),
+    string_triple: $ => seq(
+      "\"\"\"",
+      repeat(choice($._string_char, $.string_escape)),
+      "\"\"\"",
+    ),
 
     number: $ => choice($.num_binary, $.num_hexadecimal, $.num_decimal),
     num_binary: $ => /0b[01_]*/,
@@ -125,7 +140,7 @@ module.exports = grammar({
       $.expr_term_braces,
       $.expr_term_brackets,
       $.expr_term_parens,
-      $.string,
+      $._string,
       $.number,
       $.ident,
     ),

--- a/grammar/tree-sitter-rcl/grammar.js
+++ b/grammar/tree-sitter-rcl/grammar.js
@@ -18,7 +18,11 @@ module.exports = grammar({
   ],
 
   rules: {
-    source_file: $ => seq(repeat($._prefix), $._expr, repeat($._prefix)),
+    source_file: $ => seq(
+      repeat($._prefix),
+      $._expr,
+      repeat($._prefix)
+    ),
 
     // A blank is whitespace with two or more newlines. This token is distinct
     // from the regular whitespace, that Tree-sitter by default allows anywhere.
@@ -27,7 +31,8 @@ module.exports = grammar({
     // places, so we just omit it.
     // blank: $ => /[ \t\r\f]*\n[ \t\r\f]*\n[ \t\r\n\f]*/,
     comment: $ => /\/\/[^\n]*\n/,
-    _prefix: $ => $.comment,
+    shebang: $ => /#![^\n]*\n/,
+    _prefix: $ => choice($.comment, $.shebang),
 
     ident: $ => /[_A-Za-z][-_A-Za-z0-9]*/,
 

--- a/grammar/tree-sitter-rcl/grammar.js
+++ b/grammar/tree-sitter-rcl/grammar.js
@@ -6,13 +6,25 @@
 // A copy of the License has been included in the root of the repository.
 
 module.exports = grammar({
-  name: 'rcl',
+  name: "rcl",
 
   rules: {
     source_file: $ => $._prefixed_expr,
 
-    // Hmm, do I really need to define an external scanner already? ...
-    // Ah wait no, only for some tokens. I need to look into this ...
-    _prefixed_expr: $ => "TODO",
+    // A blank is whitespace with two or more newlines.
+    // Space allows arbitrary newlines, but they are not preserved in the CST.
+    blank: $ => /[ \t\r\f]*\n[ \t\r\f]*\n[ \t\r\n\f]*/,
+    _space: $ => /[ \t\r\n\f]+/,
+    comment: $ => seq("//", /[^\n]*\n/),
+    _prefix: $ => choice($.blank, $.comment, $._space),
+
+    ident: $ => /[_A-Za-z][-_A-Za-z0-9]*/,
+
+    _prefixed_expr: $ => seq(repeat($._prefix), $._expr),
+    _expr: $ => choice($.expr_stmt),
+    expr_stmt: $ => seq($._stmt, $._space, ";", $._prefixed_expr),
+
+    _stmt: $ => choice($.stmt_let),
+    stmt_let: $ => seq("let", $._space, $.ident, $._space, "=", $._prefixed_expr),
   }
 });

--- a/grammar/tree-sitter-rcl/grammar.js
+++ b/grammar/tree-sitter-rcl/grammar.js
@@ -112,7 +112,7 @@ module.exports = grammar({
       $._expr_not_op,
     ),
 
-    expr_import: $ => seq("import", $._expr),
+    expr_import: $ => seq("import", repeat($._prefix), $._expr),
 
     expr_function: $ => seq(
       field("args", $.function_args),

--- a/grammar/tree-sitter-rcl/grammar.js
+++ b/grammar/tree-sitter-rcl/grammar.js
@@ -199,6 +199,7 @@ module.exports = grammar({
     stmt_let: $ => seq(
       "let",
       field("ident", $.ident),
+      optional(seq(":", field("type", $._type_expr))),
       "=",
       field("value", $._expr),
     ),
@@ -258,6 +259,32 @@ module.exports = grammar({
     ),
 
     // One or more identifiers separated by comma, no trailing comma allowed.
-    _idents: $=> seq($.ident, repeat(seq(",", $.ident))),
+    _idents: $ => seq($.ident, repeat(seq(",", $.ident))),
+
+    _type_expr: $ => choice(
+      $.type_term,
+      $.type_apply,
+      $.type_function,
+    ),
+    type_term: $ => $.ident,
+    type_apply: $ => seq(
+      field("name", $.type_term),
+      "[",
+      field("args", $._types),
+      "]",
+    ),
+    type_function: $ => seq(
+      "(",
+      optional(field("args", $._types)),
+      ")",
+      "->",
+      field("result", $._type_expr),
+    ),
+
+    _types: $ => seq(
+      $._type_expr,
+      repeat(seq(",", $._type_expr)),
+      optional(","),
+    ),
   }
 });

--- a/grammar/tree-sitter-rcl/grammar.js
+++ b/grammar/tree-sitter-rcl/grammar.js
@@ -164,8 +164,12 @@ module.exports = grammar({
     ),
 
     _call_args: $ => choice(
+      repeat1($._prefix),
+      seq($._call_args_inner, optional(","), repeat($._prefix)),
+    ),
+    _call_args_inner: $ => choice(
       seq(repeat($._prefix), $._expr),
-      seq(repeat($._prefix), $._expr, ",", choice(optional($._call_args), repeat($._prefix))),
+      seq($._call_args_inner, ",", repeat($._prefix), $._expr),
     ),
 
     _expr_term: $ => choice(

--- a/grammar/tree-sitter-rcl/grammar.js
+++ b/grammar/tree-sitter-rcl/grammar.js
@@ -71,7 +71,7 @@ module.exports = grammar({
       seq(repeat($._prefix), $._seq, ",", choice(optional($._seqs), repeat($._prefix))),
     ),
 
-    _seq: $ => seq(
+    _seq: $ => choice(
       $._expr_op,
       seq($._expr_op, ":", $._expr),
       seq($.ident, "=", $._expr),

--- a/grammar/tree-sitter-rcl/grammar.js
+++ b/grammar/tree-sitter-rcl/grammar.js
@@ -28,21 +28,41 @@ module.exports = grammar({
 
     ident: $ => /[_A-Za-z][-_A-Za-z0-9]*/,
 
-    string: $ => choice($.string_double, $.string_triple),
+    string: $ => choice(
+      $.fstring_double,
+      $.fstring_triple,
+      $.string_double,
+      $.string_triple,
+    ),
     string_escape: $ => choice(
       /\\./,
       /\\u[0-9a-fA-F]{4}/,
       seq("\\u{", /[0-9a-fA-F]*/, "}"),
     ),
-    _string_char: $ => /[^\\"]/,
+    string_hole: $ => seq(
+      "{",
+      repeat($._prefix), $._expr, repeat($._prefix),
+      "}"
+    ),
+    _string_char: $ => /[^\\{"]/,
     string_double: $ => seq(
       "\"",
-      repeat(choice($._string_char, $.string_escape)),
+      repeat(choice($._string_char, $.string_escape, "{")),
       "\"",
     ),
     string_triple: $ => seq(
       "\"\"\"",
-      repeat(choice($._string_char, $.string_escape, "\"")),
+      repeat(choice($._string_char, $.string_escape, "\"", "{")),
+      "\"\"\"",
+    ),
+    fstring_double: $ => seq(
+      "f\"",
+      repeat(choice($._string_char, $.string_escape, $.string_hole)),
+      "\"",
+    ),
+    fstring_triple: $ => seq(
+      "f\"\"\"",
+      repeat(choice($._string_char, $.string_escape, $.string_hole, "\"")),
       "\"\"\"",
     ),
 

--- a/grammar/tree-sitter-rcl/grammar.js
+++ b/grammar/tree-sitter-rcl/grammar.js
@@ -28,7 +28,7 @@ module.exports = grammar({
 
     ident: $ => /[_A-Za-z][-_A-Za-z0-9]*/,
 
-    _string: $ => choice($.string_double, $.string_triple),
+    string: $ => choice($.string_double, $.string_triple),
     string_escape: $ => choice(
       /\\./,
       /\\u[0-9a-fA-F]{4}/,
@@ -140,7 +140,7 @@ module.exports = grammar({
       $.expr_term_braces,
       $.expr_term_brackets,
       $.expr_term_parens,
-      $._string,
+      $.string,
       $.number,
       $.ident,
     ),

--- a/grammar/tree-sitter-rcl/grammar.js
+++ b/grammar/tree-sitter-rcl/grammar.js
@@ -153,6 +153,7 @@ module.exports = grammar({
     expr_index: $ => seq(
       field("collection", $._expr_not_op),
       "[",
+      optional($._prefix),
       field("index", $._expr),
       "]",
     ),

--- a/grammar/tree-sitter-rcl/grammar.js
+++ b/grammar/tree-sitter-rcl/grammar.js
@@ -43,6 +43,11 @@ module.exports = grammar({
     // TODO: Implement the custom lexer to handle string literals.
     string: $ => /"[^"]*"/,
 
+    number: $ => choice($.num_binary, $.num_hexadecimal, $.num_decimal),
+    num_binary: $ => /0b[01_]*/,
+    num_hexadecimal: $ => /0x[0-9a-fA-F_]*/,
+    num_decimal: $ => /(0|[1-9][0-9_]*)(\.[0-9][0-9_]*)?([eE][-+]?[0-9][0-9_]*)?/,
+
     unop: $ => choice("not", "-"),
     binop: $ => choice(...Object.values(binops)),
 
@@ -107,6 +112,7 @@ module.exports = grammar({
       $.expr_term_brackets,
       $.expr_term_parens,
       $.string,
+      $.number,
       $.ident,
     ),
     expr_term_braces:   $ => seq("{", optional($._seqs), "}"),

--- a/grammar/tree-sitter-rcl/grammar.js
+++ b/grammar/tree-sitter-rcl/grammar.js
@@ -24,7 +24,10 @@ module.exports = grammar({
     // TODO: Implement the custom lexer to handle string literals.
     string: $ => /"[^"]*"/,
 
-    _expr: $ => choice($.expr_stmt),
+    _expr: $ => choice(
+      $.expr_stmt,
+      $._expr_op,
+    ),
     expr_stmt: $ => seq($._stmt, ";", repeat($._prefix), $._expr),
 
     _expr_op: $ => choice($._expr_not_op),
@@ -63,9 +66,9 @@ module.exports = grammar({
     // One or more `seq`s with an optional trailing comma. The use site has to
     // wrap it in `optional` as Tree-sitter does not support rules that match
     // the empty string.
-    _seqs: $ => seq(
-      repeat1(seq(repeat($._prefix), $._seq, ",")),
-      optional(seq(",", repeat($._prefix))),
+    _seqs: $ => choice(
+      seq(repeat($._prefix), $._seq),
+      seq(repeat($._prefix), $._seq, ",", choice(optional($._seqs), repeat($._prefix))),
     ),
 
     _seq: $ => seq(

--- a/grammar/tree-sitter-rcl/grammar.js
+++ b/grammar/tree-sitter-rcl/grammar.js
@@ -5,6 +5,9 @@
 // you may not use this file except in compliance with the License.
 // A copy of the License has been included in the root of the repository.
 
+// The names of the rules here, and the general structure, are modelled after
+// the simpler Bison grammar in //grammar/bison/grammar.y.
+
 module.exports = grammar({
   name: "rcl",
 
@@ -34,13 +37,31 @@ module.exports = grammar({
 
     _expr_not_op: $ => choice(
       $._expr_term,
-      // TODO: Add call, add index.
+      $.expr_call,
+      $.expr_index,
       $.expr_field,
+    ),
+    expr_call: $ => seq(
+      field("function", $._expr_not_op),
+      "(",
+      field("args", optional($._call_args)),
+      ")",
+    ),
+    expr_index: $ => seq(
+      field("collection", $._expr_not_op),
+      "[",
+      field("index", $._expr),
+      "]",
     ),
     expr_field: $ => seq(
       field("inner", $._expr_not_op),
       ".",
       field("field", $.ident),
+    ),
+
+    _call_args: $ => choice(
+      seq(repeat($._prefix), $._expr),
+      seq(repeat($._prefix), $._expr, ",", choice(optional($._call_args), repeat($._prefix))),
     ),
 
     _expr_term: $ => choice(

--- a/grammar/tree-sitter-rcl/grammar.js
+++ b/grammar/tree-sitter-rcl/grammar.js
@@ -22,9 +22,12 @@ module.exports = grammar({
 
     // A blank is whitespace with two or more newlines. This token is distinct
     // from the regular whitespace, that Tree-sitter by default allows anywhere.
-    blank: $ => /[ \t\r\f]*\n[ \t\r\f]*\n[ \t\r\n\f]*/,
+    // Though if we do include this token, then yes we get the node, but for
+    // syntax highlighting we don't really care and it breaks parsing in other
+    // places, so we just omit it.
+    // blank: $ => /[ \t\r\f]*\n[ \t\r\f]*\n[ \t\r\n\f]*/,
     comment: $ => /\/\/[^\n]*\n/,
-    _prefix: $ => choice($.blank, $.comment),
+    _prefix: $ => $.comment,
 
     ident: $ => /[_A-Za-z][-_A-Za-z0-9]*/,
 

--- a/grammar/tree-sitter-rcl/grammar.js
+++ b/grammar/tree-sitter-rcl/grammar.js
@@ -124,6 +124,7 @@ module.exports = grammar({
 
     _expr_op: $ => choice(
       $.expr_import,
+      $.expr_if,
       $.expr_function,
       $.expr_unop,
       $.expr_binop,
@@ -131,6 +132,15 @@ module.exports = grammar({
     ),
 
     expr_import: $ => seq("import", $._expr),
+
+    expr_if: $ => seq(
+      "if",
+      field("condition", $._expr),
+      ":",
+      field("then", $._expr),
+      "else",
+      field("else", $._expr),
+    ),
 
     expr_function: $ => seq(
       field("args", $.function_args),

--- a/grammar/tree-sitter-rcl/grammar.js
+++ b/grammar/tree-sitter-rcl/grammar.js
@@ -180,13 +180,26 @@ module.exports = grammar({
     expr_term_brackets: $ => seq("[", optional($._seqs), "]"),
     expr_term_parens:   $ => seq("(", $._expr, ")"),
 
-    _stmt: $ => seq(choice($.stmt_let)),
+    _stmt: $ => choice($.stmt_let, $.stmt_assert, $.stmt_trace),
     stmt_let: $ => seq(
       "let",
       field("ident", $.ident),
       "=",
       repeat($._prefix),
       field("value", $._expr),
+    ),
+    stmt_assert: $ => seq(
+      "assert",
+      repeat($._prefix),
+      field("condition", $._expr),
+      ",",
+      repeat($._prefix),
+      field("message", $._expr),
+    ),
+    stmt_trace: $ => seq(
+      "trace",
+      repeat($._prefix),
+      field("message", $._expr),
     ),
 
     // One or more `seq`s with an optional trailing comma. The use site has to

--- a/grammar/tree-sitter-rcl/grammar.js
+++ b/grammar/tree-sitter-rcl/grammar.js
@@ -270,7 +270,7 @@ module.exports = grammar({
     type_apply: $ => seq(
       field("name", $.type_term),
       "[",
-      field("args", $._types),
+      optional(field("args", $._types)),
       "]",
     ),
     type_function: $ => seq(

--- a/grammar/tree-sitter-rcl/grammar.js
+++ b/grammar/tree-sitter-rcl/grammar.js
@@ -206,8 +206,12 @@ module.exports = grammar({
     // wrap it in `optional` as Tree-sitter does not support rules that match
     // the empty string.
     _seqs: $ => choice(
+      repeat1($._prefix),
+      seq($._seqs_inner, optional(","), repeat($._prefix)),
+    ),
+    _seqs_inner: $ => choice(
       seq(repeat($._prefix), $._seq),
-      seq(repeat($._prefix), $._seq, ",", choice(optional($._seqs), repeat($._prefix))),
+      seq($._seqs_inner, ",", repeat($._prefix), $._seq),
     ),
 
     _seq: $ => choice(

--- a/grammar/tree-sitter-rcl/grammar.js
+++ b/grammar/tree-sitter-rcl/grammar.js
@@ -1,0 +1,18 @@
+// RCL -- A reasonable configuration language.
+// Copyright 2024 Ruud van Asseldonk
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// A copy of the License has been included in the root of the repository.
+
+module.exports = grammar({
+  name: 'rcl',
+
+  rules: {
+    source_file: $ => $._prefixed_expr,
+
+    // Hmm, do I really need to define an external scanner already? ...
+    // Ah wait no, only for some tokens. I need to look into this ...
+    _prefixed_expr: $ => "TODO",
+  }
+});

--- a/grammar/tree-sitter-rcl/grammar.js
+++ b/grammar/tree-sitter-rcl/grammar.js
@@ -139,8 +139,16 @@ module.exports = grammar({
       $.seq_if,
     ),
     seq_elem: $ => $._expr_op,
-    seq_assoc_expr: $ => seq($._expr_op, ":", $._expr),
-    seq_assoc_ident: $ => seq($.ident, "=", $._expr),
+    seq_assoc_expr: $ => seq(
+      field("field", $._expr_op),
+      ":",
+      field("value", $._expr),
+    ),
+    seq_assoc_ident: $ => seq(
+      field("field", $.ident),
+      "=",
+      field("value", $._expr),
+    ),
     // TODO: I need to allow a prefix here. Will the fuzzer find it?
     seq_stmt: $ => seq($._stmt, ";", $._seq),
     seq_for: $ => seq(

--- a/grammar/tree-sitter-rcl/grammar.js
+++ b/grammar/tree-sitter-rcl/grammar.js
@@ -18,7 +18,7 @@ module.exports = grammar({
   ],
 
   rules: {
-    source_file: $ => seq(repeat($._prefix), $._expr),
+    source_file: $ => seq(repeat($._prefix), $._expr, repeat($._prefix)),
 
     // A blank is whitespace with two or more newlines. This token is distinct
     // from the regular whitespace, that Tree-sitter by default allows anywhere.

--- a/grammar/tree-sitter-rcl/grammar.js
+++ b/grammar/tree-sitter-rcl/grammar.js
@@ -72,13 +72,31 @@ module.exports = grammar({
     ),
 
     _seq: $ => choice(
-      $._expr_op,
-      seq($._expr_op, ":", $._expr),
-      seq($.ident, "=", $._expr),
-      // TODO: I need to allow a prefix here. Will the fuzzer find it?
-      seq($._stmt, ";", $._seq),
-      seq("for", $._idents, "in", $._expr, ":", $._seq),
-      seq("if", $._expr, ":", $._seq),
+      $.seq_elem,
+      $.seq_assoc_expr,
+      $.seq_assoc_ident,
+      $.seq_stmt,
+      $.seq_for,
+      $.seq_if,
+    ),
+    seq_elem: $ => $._expr_op,
+    seq_assoc_expr: $ => seq($._expr_op, ":", $._expr),
+    seq_assoc_ident: $ => seq($.ident, "=", $._expr),
+    // TODO: I need to allow a prefix here. Will the fuzzer find it?
+    seq_stmt: $ => seq($._stmt, ";", $._seq),
+    seq_for: $ => seq(
+      "for",
+      field("idents", $._idents),
+      "in",
+      field("collection", $._expr),
+      ":",
+      field("body", $._seq),
+    ),
+    seq_if: $ => seq(
+      "if",
+      field("condition", $._expr),
+      ":",
+      field("body", $._seq),
     ),
 
     // One or more identifiers separated by comma, no trailing comma allowed.

--- a/grammar/tree-sitter-rcl/package.json
+++ b/grammar/tree-sitter-rcl/package.json
@@ -4,9 +4,14 @@
   "tree-sitter": [
     {
       "scope": "source.rcl",
-      "file-types": ["rcl"],
+      "file-types": [
+        "rcl"
+      ],
       "injection-regex": "rcl",
-      "highlights": ["queries/highlights.scm"]
+      "highlights": [
+        "queries/highlights.scm"
+      ]
     }
-  ]
+  ],
+  "main": "bindings/node"
 }

--- a/grammar/tree-sitter-rcl/package.json
+++ b/grammar/tree-sitter-rcl/package.json
@@ -1,0 +1,12 @@
+{
+  "// 1": "This file is only here to make `tree-sitter highlight` work,",
+  "// 2": "we don't use a JS package manager, so the file is otherwise empty.",
+  "tree-sitter": [
+    {
+      "scope": "source.rcl",
+      "file-types": ["rcl"],
+      "injection-regex": "rcl",
+      "highlights": ["queries/highlights.scm"]
+    }
+  ]
+}

--- a/grammar/tree-sitter-rcl/queries/highlights.scm
+++ b/grammar/tree-sitter-rcl/queries/highlights.scm
@@ -1,15 +1,15 @@
-[
-  "for"
-  "if"
-  "import"
-  "in"
-  "let"
-  (unop_keyword)
-  (binop_keyword)
-] @keyword
+["for" "in"] @keyword
+["assert" "trace"] @keyword
+["if"] @keyword
+["import"] @keyword
+["let"] @keyword
+(unop_keyword) @keyword
+(binop_keyword) @keyword
 
 (comment) @comment
 (number) @number
+(bool) @constant
+(null) @constant
 
 (string) @string
 (string_escape) @string.special

--- a/grammar/tree-sitter-rcl/queries/highlights.scm
+++ b/grammar/tree-sitter-rcl/queries/highlights.scm
@@ -5,8 +5,9 @@
   "let"
 ] @keyword
 
-(string) @string
 (comment) @comment
+(string) @string
+(number) @constant.numeric
 
 (seq_assoc_expr field: (string) @property)
 (seq_assoc_ident field: (ident) @property)

--- a/grammar/tree-sitter-rcl/queries/highlights.scm
+++ b/grammar/tree-sitter-rcl/queries/highlights.scm
@@ -8,9 +8,9 @@
 ] @keyword
 
 (comment) @comment
-(number) @constant.numeric
+(number) @number
 (string) @string
-(string_escape) @string.escape
+(string_escape) @string.special
 
 (seq_assoc_expr field: (string) @property)
 (seq_assoc_ident field: (ident) @property)

--- a/grammar/tree-sitter-rcl/queries/highlights.scm
+++ b/grammar/tree-sitter-rcl/queries/highlights.scm
@@ -1,6 +1,7 @@
 [
   "for"
   "if"
+  "import"
   "in"
   "let"
   (unop_keyword)

--- a/grammar/tree-sitter-rcl/queries/highlights.scm
+++ b/grammar/tree-sitter-rcl/queries/highlights.scm
@@ -1,0 +1,6 @@
+[
+  "if"
+  "in"
+  "let"
+] @keyword
+(string) @string

--- a/grammar/tree-sitter-rcl/queries/highlights.scm
+++ b/grammar/tree-sitter-rcl/queries/highlights.scm
@@ -8,8 +8,12 @@
 ] @keyword
 
 (comment) @comment
-(string) @string
 (number) @constant.numeric
+[
+  (string_double)
+  (string_triple)
+] @string
+(string_escape) @string.escape
 
 (seq_assoc_expr field: (string) @property)
 (seq_assoc_ident field: (ident) @property)

--- a/grammar/tree-sitter-rcl/queries/highlights.scm
+++ b/grammar/tree-sitter-rcl/queries/highlights.scm
@@ -3,6 +3,8 @@
   "if"
   "in"
   "let"
+  (unop_keyword)
+  (binop_keyword)
 ] @keyword
 
 (comment) @comment

--- a/grammar/tree-sitter-rcl/queries/highlights.scm
+++ b/grammar/tree-sitter-rcl/queries/highlights.scm
@@ -9,10 +9,7 @@
 
 (comment) @comment
 (number) @constant.numeric
-[
-  (string_double)
-  (string_triple)
-] @string
+(string) @string
 (string_escape) @string.escape
 
 (seq_assoc_expr field: (string) @property)

--- a/grammar/tree-sitter-rcl/queries/highlights.scm
+++ b/grammar/tree-sitter-rcl/queries/highlights.scm
@@ -9,8 +9,10 @@
 
 (comment) @comment
 (number) @number
+
 (string) @string
 (string_escape) @string.special
+(string_hole (["{" "}"] @string.special))
 
 (seq_assoc_expr field: (string) @property)
 (seq_assoc_ident field: (ident) @property)

--- a/grammar/tree-sitter-rcl/queries/highlights.scm
+++ b/grammar/tree-sitter-rcl/queries/highlights.scm
@@ -1,6 +1,6 @@
 ["for" "in"] @keyword
 ["assert" "trace"] @keyword
-["if"] @keyword
+["if" "else"] @keyword
 ["import"] @keyword
 ["let"] @keyword
 (unop_keyword) @keyword

--- a/grammar/tree-sitter-rcl/queries/highlights.scm
+++ b/grammar/tree-sitter-rcl/queries/highlights.scm
@@ -17,3 +17,5 @@
 
 (seq_assoc_expr field: (string) @property)
 (seq_assoc_ident field: (ident) @property)
+
+(type_term) @type

--- a/grammar/tree-sitter-rcl/queries/highlights.scm
+++ b/grammar/tree-sitter-rcl/queries/highlights.scm
@@ -1,6 +1,12 @@
 [
+  "for"
   "if"
   "in"
   "let"
 ] @keyword
+
 (string) @string
+(comment) @comment
+
+(seq_assoc_expr field: (string) @property)
+(seq_assoc_ident field: (ident) @property)

--- a/grammar/tree-sitter-rcl/queries/highlights_helix.scm
+++ b/grammar/tree-sitter-rcl/queries/highlights_helix.scm
@@ -17,3 +17,5 @@
 
 (seq_assoc_expr field: (string) @attribute)
 (seq_assoc_ident field: (ident) @attribute)
+
+(type_term) @type

--- a/grammar/tree-sitter-rcl/queries/highlights_helix.scm
+++ b/grammar/tree-sitter-rcl/queries/highlights_helix.scm
@@ -5,8 +5,9 @@
   "let"
 ] @keyword
 
-(string) @string
 (comment) @comment
+(string) @string
+(number) @constant.numeric
 
 (seq_assoc_expr field: (string) @attribute)
 (seq_assoc_ident field: (ident) @attribute)

--- a/grammar/tree-sitter-rcl/queries/highlights_helix.scm
+++ b/grammar/tree-sitter-rcl/queries/highlights_helix.scm
@@ -1,6 +1,6 @@
 ["for" "in"] @keyword.control.repeat
 ["assert" "trace"] @keyword.exception
-["if"] @keyword.control.conditional
+["if" "else"] @keyword.control.conditional
 ["import"] @keyword.control.import
 ["let"] @keyword.storage.let
 (unop_keyword) @keyword.operator

--- a/grammar/tree-sitter-rcl/queries/highlights_helix.scm
+++ b/grammar/tree-sitter-rcl/queries/highlights_helix.scm
@@ -1,15 +1,15 @@
-[
-  "for"
-  "if"
-  "import"
-  "in"
-  "let"
-  (unop_keyword)
-  (binop_keyword)
-] @keyword
+["for" "in"] @keyword.control.repeat
+["assert" "trace"] @keyword.exception
+["if"] @keyword.control.conditional
+["import"] @keyword.control.import
+["let"] @keyword.storage.let
+(unop_keyword) @keyword.operator
+(binop_keyword) @keyword.operator
 
 (comment) @comment
 (number) @constant.numeric
+(bool) @constant.builtin.boolean
+(null) @constant.builtin
 
 (string) @string
 (string_escape) @string.special

--- a/grammar/tree-sitter-rcl/queries/highlights_helix.scm
+++ b/grammar/tree-sitter-rcl/queries/highlights_helix.scm
@@ -1,6 +1,7 @@
 [
   "for"
   "if"
+  "import"
   "in"
   "let"
   (unop_keyword)

--- a/grammar/tree-sitter-rcl/queries/highlights_helix.scm
+++ b/grammar/tree-sitter-rcl/queries/highlights_helix.scm
@@ -1,0 +1,12 @@
+[
+  "for"
+  "if"
+  "in"
+  "let"
+] @keyword
+
+(string) @string
+(comment) @comment
+
+(seq_assoc_expr field: (string) @attribute)
+(seq_assoc_ident field: (ident) @attribute)

--- a/grammar/tree-sitter-rcl/queries/highlights_helix.scm
+++ b/grammar/tree-sitter-rcl/queries/highlights_helix.scm
@@ -8,8 +8,12 @@
 ] @keyword
 
 (comment) @comment
-(string) @string
 (number) @constant.numeric
+[
+  (string_double)
+  (string_triple)
+] @string
+(string_escape) @string.special
 
 (seq_assoc_expr field: (string) @attribute)
 (seq_assoc_ident field: (ident) @attribute)

--- a/grammar/tree-sitter-rcl/queries/highlights_helix.scm
+++ b/grammar/tree-sitter-rcl/queries/highlights_helix.scm
@@ -9,10 +9,7 @@
 
 (comment) @comment
 (number) @constant.numeric
-[
-  (string_double)
-  (string_triple)
-] @string
+(string) @string
 (string_escape) @string.special
 
 (seq_assoc_expr field: (string) @attribute)

--- a/grammar/tree-sitter-rcl/queries/highlights_helix.scm
+++ b/grammar/tree-sitter-rcl/queries/highlights_helix.scm
@@ -3,6 +3,8 @@
   "if"
   "in"
   "let"
+  (unop_keyword)
+  (binop_keyword)
 ] @keyword
 
 (comment) @comment

--- a/grammar/tree-sitter-rcl/queries/highlights_helix.scm
+++ b/grammar/tree-sitter-rcl/queries/highlights_helix.scm
@@ -9,8 +9,10 @@
 
 (comment) @comment
 (number) @constant.numeric
+
 (string) @string
 (string_escape) @string.special
+(string_hole (["{" "}"] @string.special))
 
 (seq_assoc_expr field: (string) @attribute)
 (seq_assoc_ident field: (ident) @attribute)

--- a/grammar/tree-sitter-rcl/queries/highlights_nvim.scm
+++ b/grammar/tree-sitter-rcl/queries/highlights_nvim.scm
@@ -1,6 +1,6 @@
 ["for" "in"] @keyword.repeat
 ["assert" "trace"] @keyword.debug
-["if"] @keyword.conditional
+["if" "else"] @keyword.conditional
 ["import"] @keyword.import
 ["let"] @keyword.storage
 (unop_keyword) @keyword.operator

--- a/grammar/tree-sitter-rcl/queries/highlights_nvim.scm
+++ b/grammar/tree-sitter-rcl/queries/highlights_nvim.scm
@@ -1,0 +1,12 @@
+[
+  "for"
+  "if"
+  "in"
+  "let"
+] @keyword
+
+(string) @string
+(comment) @comment
+
+(seq_assoc_expr field: (string) @property)
+(seq_assoc_ident field: (ident) @property)

--- a/grammar/tree-sitter-rcl/queries/highlights_nvim.scm
+++ b/grammar/tree-sitter-rcl/queries/highlights_nvim.scm
@@ -8,8 +8,12 @@
 ] @keyword
 
 (comment) @comment
-(string) @string
 (number) @number
+[
+  (string_double)
+  (string_triple)
+] @string
+(string_escape) @string.escape
 
 (seq_assoc_expr field: (string) @property)
 (seq_assoc_ident field: (ident) @property)

--- a/grammar/tree-sitter-rcl/queries/highlights_nvim.scm
+++ b/grammar/tree-sitter-rcl/queries/highlights_nvim.scm
@@ -9,8 +9,10 @@
 
 (comment) @comment
 (number) @number
+
 (string) @string
 (string_escape) @string.escape
+(string_hole (["{" "}"] @string.escape))
 
 (seq_assoc_expr field: (string) @property)
 (seq_assoc_ident field: (ident) @property)

--- a/grammar/tree-sitter-rcl/queries/highlights_nvim.scm
+++ b/grammar/tree-sitter-rcl/queries/highlights_nvim.scm
@@ -1,6 +1,7 @@
 [
   "for"
   "if"
+  "import"
   "in"
   "let"
   (unop_keyword)

--- a/grammar/tree-sitter-rcl/queries/highlights_nvim.scm
+++ b/grammar/tree-sitter-rcl/queries/highlights_nvim.scm
@@ -3,6 +3,8 @@
   "if"
   "in"
   "let"
+  (unop_keyword)
+  (binop_keyword)
 ] @keyword
 
 (comment) @comment

--- a/grammar/tree-sitter-rcl/queries/highlights_nvim.scm
+++ b/grammar/tree-sitter-rcl/queries/highlights_nvim.scm
@@ -5,8 +5,9 @@
   "let"
 ] @keyword
 
-(string) @string
 (comment) @comment
+(string) @string
+(number) @number
 
 (seq_assoc_expr field: (string) @property)
 (seq_assoc_ident field: (ident) @property)

--- a/grammar/tree-sitter-rcl/queries/highlights_nvim.scm
+++ b/grammar/tree-sitter-rcl/queries/highlights_nvim.scm
@@ -17,3 +17,5 @@
 
 (seq_assoc_expr field: (string) @property)
 (seq_assoc_ident field: (ident) @property)
+
+(type_term) @type

--- a/grammar/tree-sitter-rcl/queries/highlights_nvim.scm
+++ b/grammar/tree-sitter-rcl/queries/highlights_nvim.scm
@@ -1,15 +1,15 @@
-[
-  "for"
-  "if"
-  "import"
-  "in"
-  "let"
-  (unop_keyword)
-  (binop_keyword)
-] @keyword
+["for" "in"] @keyword.repeat
+["assert" "trace"] @keyword.debug
+["if"] @keyword.conditional
+["import"] @keyword.import
+["let"] @keyword.storage
+(unop_keyword) @keyword.operator
+(binop_keyword) @keyword.operator
 
 (comment) @comment
 (number) @number
+(bool) @boolean
+(null) @constant.builtin
 
 (string) @string
 (string_escape) @string.escape

--- a/grammar/tree-sitter-rcl/queries/highlights_nvim.scm
+++ b/grammar/tree-sitter-rcl/queries/highlights_nvim.scm
@@ -9,10 +9,7 @@
 
 (comment) @comment
 (number) @number
-[
-  (string_double)
-  (string_triple)
-] @string
+(string) @string
 (string_escape) @string.escape
 
 (seq_assoc_expr field: (string) @property)

--- a/grammar/tree-sitter-rcl/test/corpus/expr.txt
+++ b/grammar/tree-sitter-rcl/test/corpus/expr.txt
@@ -366,3 +366,17 @@ import
   (expr_import
     (comment)
     (string (string_double))))
+
+===========
+Conditional
+===========
+
+if true: null else false
+
+---
+
+(source_file
+  (expr_if
+    condition: (bool)
+    then: (null)
+    else: (bool)))

--- a/grammar/tree-sitter-rcl/test/corpus/expr.txt
+++ b/grammar/tree-sitter-rcl/test/corpus/expr.txt
@@ -303,6 +303,35 @@ Function with parens, 2 args
     (function_args (ident) (ident))
     (string (string_double))))
 
+====================
+Function with 0 args
+====================
+
+() => "a"
+
+---
+
+(source_file
+  (expr_function
+    (function_args)
+    (string (string_double))))
+
+================================
+Function with 0 args and comment
+================================
+
+(
+  // A comment inside the empty argument list.
+) => "a"
+
+---
+
+(source_file
+  (expr_function
+    (function_args
+      (comment))
+    (string (string_double))))
+
 =====================================
 Not a function but parenthesized expr
 =====================================

--- a/grammar/tree-sitter-rcl/test/corpus/expr.txt
+++ b/grammar/tree-sitter-rcl/test/corpus/expr.txt
@@ -117,3 +117,48 @@ not not x
     (expr_unop
       (unop)
       (ident))))
+
+=========
+Binop and
+=========
+
+x and y
+
+---
+
+(source_file
+  (expr_binop_and
+    (ident)
+    (ident)))
+
+=============
+Binop and and
+=============
+
+x and y and z
+
+---
+
+(source_file
+  (expr_binop_and
+    (ident)
+    (ident)
+    (ident)))
+
+============
+Binop and or
+============
+
+// Mixing operators without parens is an error.
+x and y or z
+
+---
+
+(source_file
+  (comment)
+  (expr_binop_and
+    (ident)
+    (ERROR
+      (ident)
+      (ident))
+    (ident)))

--- a/grammar/tree-sitter-rcl/test/corpus/expr.txt
+++ b/grammar/tree-sitter-rcl/test/corpus/expr.txt
@@ -59,7 +59,7 @@ f("x",)
 (source_file
   (expr_call
     (ident)
-    (string)))
+    (string_double)))
 
 ======================
 Call no trailing comma
@@ -72,7 +72,7 @@ f("x", y)
 (source_file
   (expr_call
     (ident)
-    (string)
+    (string_double)
     (ident)))
 
 =====
@@ -86,7 +86,7 @@ collection["index"]
 (source_file
   (expr_index
     (ident)
-    (string)))
+    (string_double)))
 
 ========
 Unop not
@@ -230,7 +230,7 @@ x => "a"
 (source_file
   (expr_function
     (function_args (ident))
-    (string)))
+    (string_double)))
 
 =====================================
 Function with parens, 1 arg, no comma
@@ -243,7 +243,7 @@ Function with parens, 1 arg, no comma
 (source_file
   (expr_function
     (function_args (ident))
-    (string)))
+    (string_double)))
 
 ==================================
 Function with parens, 1 arg, comma
@@ -256,7 +256,7 @@ Function with parens, 1 arg, comma
 (source_file
   (expr_function
     (function_args (ident))
-    (string)))
+    (string_double)))
 
 ==================================
 Function with parens, 2 args
@@ -269,7 +269,7 @@ Function with parens, 2 args
 (source_file
   (expr_function
     (function_args (ident) (ident))
-    (string)))
+    (string_double)))
 
 =====================================
 Not a function but parenthesized expr

--- a/grammar/tree-sitter-rcl/test/corpus/expr.txt
+++ b/grammar/tree-sitter-rcl/test/corpus/expr.txt
@@ -35,3 +35,55 @@ Idents
       (ident))
     (seq_elem
       (ident))))
+
+==========
+Call empty
+==========
+
+f()
+
+---
+
+(source_file
+  (expr_call
+    (ident)))
+
+===================
+Call trailing comma
+===================
+
+f("x",)
+
+---
+
+(source_file
+  (expr_call
+    (ident)
+    (string)))
+
+======================
+Call no trailing comma
+======================
+
+f("x", y)
+
+---
+
+(source_file
+  (expr_call
+    (ident)
+    (string)
+    (ident)))
+
+=====
+Index
+=====
+
+collection["index"]
+
+---
+
+(source_file
+  (expr_index
+    (ident)
+    (string)))

--- a/grammar/tree-sitter-rcl/test/corpus/expr.txt
+++ b/grammar/tree-sitter-rcl/test/corpus/expr.txt
@@ -59,7 +59,7 @@ f("x",)
 (source_file
   (expr_call
     (ident)
-    (string_double)))
+    (string (string_double))))
 
 ======================
 Call no trailing comma
@@ -72,7 +72,7 @@ f("x", y)
 (source_file
   (expr_call
     (ident)
-    (string_double)
+    (string (string_double))
     (ident)))
 
 =====
@@ -86,7 +86,7 @@ collection["index"]
 (source_file
   (expr_index
     (ident)
-    (string_double)))
+    (string (string_double))))
 
 ========
 Unop not
@@ -230,7 +230,7 @@ x => "a"
 (source_file
   (expr_function
     (function_args (ident))
-    (string_double)))
+    (string (string_double))))
 
 =====================================
 Function with parens, 1 arg, no comma
@@ -243,7 +243,7 @@ Function with parens, 1 arg, no comma
 (source_file
   (expr_function
     (function_args (ident))
-    (string_double)))
+    (string (string_double))))
 
 ==================================
 Function with parens, 1 arg, comma
@@ -256,7 +256,7 @@ Function with parens, 1 arg, comma
 (source_file
   (expr_function
     (function_args (ident))
-    (string_double)))
+    (string (string_double))))
 
 ==================================
 Function with parens, 2 args
@@ -269,7 +269,7 @@ Function with parens, 2 args
 (source_file
   (expr_function
     (function_args (ident) (ident))
-    (string_double)))
+    (string (string_double))))
 
 =====================================
 Not a function but parenthesized expr

--- a/grammar/tree-sitter-rcl/test/corpus/expr.txt
+++ b/grammar/tree-sitter-rcl/test/corpus/expr.txt
@@ -280,3 +280,13 @@ Not a function but parenthesized expr
 ---
 
 (source_file (expr_term_parens (ident)))
+
+======
+Import
+======
+
+import "foo.rcl"
+
+---
+
+(source_file (expr_import (string (string_double))))

--- a/grammar/tree-sitter-rcl/test/corpus/expr.txt
+++ b/grammar/tree-sitter-rcl/test/corpus/expr.txt
@@ -48,6 +48,21 @@ f()
   (expr_call
     (ident)))
 
+==================
+Call empty comment
+==================
+
+f(
+  // Empty
+)
+
+---
+
+(source_file
+  (expr_call
+    (ident)
+    (comment)))
+
 ===================
 Call trailing comma
 ===================

--- a/grammar/tree-sitter-rcl/test/corpus/expr.txt
+++ b/grammar/tree-sitter-rcl/test/corpus/expr.txt
@@ -1,6 +1,6 @@
-=======================
-Seq expression {} empty
-=======================
+========
+Empty {}
+========
 
 {}
 
@@ -9,29 +9,29 @@ Seq expression {} empty
 (source_file
   (expr_term_braces))
 
-========================
-Seq expression {} idents
-========================
+======
+Idents
+======
 
-{ x, y, z }
-
----
-
-(source_file
-  (expr_term_braces
-    (ident)
-    (ident)
-    (ident)))
-
-=========================================
-Seq expression {} idents (trailing comma)
-=========================================
-
-{ x, y, }
+[
+  CamelCase1337,
+  snake_case,
+  __internal_snake_case,
+  SCREAMING_SNAKE_CASE,
+  kebap-case,
+]
 
 ---
 
 (source_file
-  (expr_term_braces
-    (ident)
-    (ident)))
+  (expr_term_brackets
+    (seq_elem
+      (ident))
+    (seq_elem
+      (ident))
+    (seq_elem
+      (ident))
+    (seq_elem
+      (ident))
+    (seq_elem
+      (ident))))

--- a/grammar/tree-sitter-rcl/test/corpus/expr.txt
+++ b/grammar/tree-sitter-rcl/test/corpus/expr.txt
@@ -87,3 +87,33 @@ collection["index"]
   (expr_index
     (ident)
     (string)))
+
+========
+Unop not
+========
+
+not x
+
+---
+
+(source_file
+  (expr_unop
+    (unop)
+    (ident)))
+
+============
+Unop not not
+============
+
+// This is fine without parens.
+not not x
+
+---
+
+(source_file
+  (comment)
+  (expr_unop
+    (unop)
+    (expr_unop
+      (unop)
+      (ident))))

--- a/grammar/tree-sitter-rcl/test/corpus/expr.txt
+++ b/grammar/tree-sitter-rcl/test/corpus/expr.txt
@@ -18,4 +18,20 @@ Seq expression {} idents
 ---
 
 (source_file
-  (TODO))
+  (expr_term_braces
+    (ident)
+    (ident)
+    (ident)))
+
+=========================================
+Seq expression {} idents (trailing comma)
+=========================================
+
+{ x, y, }
+
+---
+
+(source_file
+  (expr_term_braces
+    (ident)
+    (ident)))

--- a/grammar/tree-sitter-rcl/test/corpus/expr.txt
+++ b/grammar/tree-sitter-rcl/test/corpus/expr.txt
@@ -162,3 +162,54 @@ x and y or z
       (ident)
       (ident))
     (ident)))
+
+==============
+Number decimal
+==============
+
+[0, 10, 1_0, 0.1, 0.1_0, 1e12]
+
+---
+
+(source_file
+  (expr_term_brackets
+    (seq_elem (number (num_decimal)))
+    (seq_elem (number (num_decimal)))
+    (seq_elem (number (num_decimal)))
+    (seq_elem (number (num_decimal)))
+    (seq_elem (number (num_decimal)))
+    (seq_elem (number (num_decimal)))))
+
+======================
+Number invalid decimal
+======================
+
+00
+
+---
+
+(source_file
+  (number (num_decimal))
+  (ERROR (num_decimal)))
+
+=============
+Number binary
+=============
+
+0b11_00
+
+---
+
+(source_file
+  (number (num_binary)))
+
+==================
+Number hexadecimal
+==================
+
+0xff_01
+
+---
+
+(source_file
+  (number (num_hexadecimal)))

--- a/grammar/tree-sitter-rcl/test/corpus/expr.txt
+++ b/grammar/tree-sitter-rcl/test/corpus/expr.txt
@@ -322,3 +322,18 @@ import "foo.rcl"
 ---
 
 (source_file (expr_import (string (string_double))))
+
+===================
+Import with comment
+===================
+
+import
+  // The file to import.
+  "foo.rcl"
+
+---
+
+(source_file
+  (expr_import
+    (comment)
+    (string (string_double))))

--- a/grammar/tree-sitter-rcl/test/corpus/expr.txt
+++ b/grammar/tree-sitter-rcl/test/corpus/expr.txt
@@ -1,0 +1,21 @@
+=======================
+Seq expression {} empty
+=======================
+
+{}
+
+---
+
+(source_file
+  (expr_term_braces))
+
+========================
+Seq expression {} idents
+========================
+
+{ x, y, z }
+
+---
+
+(source_file
+  (TODO))

--- a/grammar/tree-sitter-rcl/test/corpus/expr.txt
+++ b/grammar/tree-sitter-rcl/test/corpus/expr.txt
@@ -218,3 +218,55 @@ Number hexadecimal
 
 (source_file
   (number (num_hexadecimal)))
+
+==================
+Function no parens
+==================
+
+x => "a"
+
+---
+
+(source_file
+  (expr_function
+    (function_args (ident))
+    (string)))
+
+=====================================
+Function with parens, 1 arg, no comma
+=====================================
+
+(x) => "a"
+
+---
+
+(source_file
+  (expr_function
+    (function_args (ident))
+    (string)))
+
+==================================
+Function with parens, 1 arg, comma
+==================================
+
+(x,) => "a"
+
+---
+
+(source_file
+  (expr_function
+    (function_args (ident))
+    (string)))
+
+==================================
+Function with parens, 2 args
+==================================
+
+(x, y) => "a"
+
+---
+
+(source_file
+  (expr_function
+    (function_args (ident) (ident))
+    (string)))

--- a/grammar/tree-sitter-rcl/test/corpus/expr.txt
+++ b/grammar/tree-sitter-rcl/test/corpus/expr.txt
@@ -88,6 +88,23 @@ collection["index"]
     (ident)
     (string (string_double))))
 
+==================
+Index with comment
+==================
+
+collection[
+  // A comment
+  "index"
+]
+
+---
+
+(source_file
+  (expr_index
+    (ident)
+    (comment)
+    (string (string_double))))
+
 ========
 Unop not
 ========

--- a/grammar/tree-sitter-rcl/test/corpus/expr.txt
+++ b/grammar/tree-sitter-rcl/test/corpus/expr.txt
@@ -270,3 +270,13 @@ Function with parens, 2 args
   (expr_function
     (function_args (ident) (ident))
     (string)))
+
+=====================================
+Not a function but parenthesized expr
+=====================================
+
+(x)
+
+---
+
+(source_file (expr_term_parens (ident)))

--- a/grammar/tree-sitter-rcl/test/corpus/expr.txt
+++ b/grammar/tree-sitter-rcl/test/corpus/expr.txt
@@ -98,7 +98,7 @@ not x
 
 (source_file
   (expr_unop
-    (unop)
+    (unop (unop_keyword))
     (ident)))
 
 ============
@@ -113,9 +113,9 @@ not not x
 (source_file
   (comment)
   (expr_unop
-    (unop)
+    (unop (unop_keyword))
     (expr_unop
-      (unop)
+      (unop (unop_keyword))
       (ident))))
 
 =========
@@ -127,8 +127,9 @@ x and y
 ---
 
 (source_file
-  (expr_binop_and
+  (expr_binop
     (ident)
+    (binop (binop_keyword))
     (ident)))
 
 =============
@@ -140,27 +141,31 @@ x and y and z
 ---
 
 (source_file
-  (expr_binop_and
+  (expr_binop
     (ident)
+    (binop (binop_keyword))
     (ident)
+    (binop (binop_keyword))
     (ident)))
 
 ============
 Binop and or
 ============
 
-// Mixing operators without parens is an error.
-x and y or z
+// Mixing operators without parens is an error in RCL,
+// but allowed by the Tree-sitter paser.
+x and y + z
 
 ---
 
 (source_file
   (comment)
-  (expr_binop_and
+  (comment)
+  (expr_binop
     (ident)
-    (ERROR
-      (ident)
-      (ident))
+    (binop (binop_keyword))
+    (ident)
+    (binop)
     (ident)))
 
 ==============

--- a/grammar/tree-sitter-rcl/test/corpus/seq.txt
+++ b/grammar/tree-sitter-rcl/test/corpus/seq.txt
@@ -1,0 +1,58 @@
+=====
+Empty
+=====
+
+{}
+
+---
+
+(source_file
+  (expr_term_braces))
+
+======
+Idents
+======
+
+{ x, y, z }
+
+---
+
+(source_file
+  (expr_term_braces
+    (seq_elem
+      (ident))
+    (seq_elem
+      (ident))
+    (seq_elem
+      (ident))))
+
+=======================
+Idents (trailing comma)
+=======================
+
+{ x, y, }
+
+---
+
+(source_file
+  (expr_term_braces
+    (seq_elem
+      (ident))
+    (seq_elem
+      (ident))))
+
+==========
+For single
+==========
+
+{ for x in y: z }
+
+---
+
+(source_file
+  (expr_term_braces
+    (seq_for
+      (ident)
+      (ident)
+      (seq_elem
+        (ident)))))

--- a/grammar/tree-sitter-rcl/test/corpus/seq.txt
+++ b/grammar/tree-sitter-rcl/test/corpus/seq.txt
@@ -6,8 +6,19 @@ Empty
 
 ---
 
-(source_file
-  (expr_term_braces))
+(source_file (expr_term_braces))
+
+==================
+Empty with comment
+==================
+
+[
+  // Empty
+]
+
+---
+
+(source_file (expr_term_brackets (comment)))
 
 ======
 Idents

--- a/grammar/tree-sitter-rcl/test/corpus/stmt.txt
+++ b/grammar/tree-sitter-rcl/test/corpus/stmt.txt
@@ -1,0 +1,43 @@
+===
+Let
+===
+
+let x = y; x
+
+---
+
+(source_file
+  (expr_stmt
+    (stmt_let
+      ident: (ident)
+      value: (ident))
+    (ident)))
+
+======
+Assert
+======
+
+assert p == q, r; s
+
+---
+
+(source_file
+  (expr_stmt
+    (stmt_assert
+      condition: (expr_binop (ident) (binop) (ident))
+      message: (ident))
+    (ident)))
+
+=====
+Trace
+=====
+
+trace p; q
+
+---
+
+(source_file
+  (expr_stmt
+    (stmt_trace
+      message: (ident))
+    (ident)))

--- a/grammar/tree-sitter-rcl/test/corpus/string.txt
+++ b/grammar/tree-sitter-rcl/test/corpus/string.txt
@@ -47,3 +47,18 @@ Escape quote
 ---
 
 (source_file (string (string_double (string_escape))))
+
+=============
+Triple quoted
+=============
+
+"""
+Foo "bar"
+""Two doesn't end the string""
+Escaped \""" does not either.
+But three does:
+"""
+
+---
+
+(source_file (string (string_triple (string_escape))))

--- a/grammar/tree-sitter-rcl/test/corpus/string.txt
+++ b/grammar/tree-sitter-rcl/test/corpus/string.txt
@@ -6,7 +6,7 @@ Empty
 
 ---
 
-(source_file (string_double))
+(source_file (string (string_double)))
 
 =====
 Basic
@@ -16,7 +16,7 @@ Basic
 
 ---
 
-(source_file (string_double))
+(source_file (string (string_double)))
 
 ========================
 Escape unicode no braces
@@ -26,7 +26,7 @@ Escape unicode no braces
 
 ---
 
-(source_file (string_double (string_escape)))
+(source_file (string (string_double (string_escape))))
 
 =====================
 Escape unicode braces
@@ -36,7 +36,7 @@ Escape unicode braces
 
 ---
 
-(source_file (string_double (string_escape)))
+(source_file (string (string_double (string_escape))))
 
 ============
 Escape quote
@@ -46,4 +46,4 @@ Escape quote
 
 ---
 
-(source_file (string_double (string_escape)))
+(source_file (string (string_double (string_escape))))

--- a/grammar/tree-sitter-rcl/test/corpus/string.txt
+++ b/grammar/tree-sitter-rcl/test/corpus/string.txt
@@ -1,0 +1,49 @@
+=====
+Empty
+=====
+
+""
+
+---
+
+(source_file (string_double))
+
+=====
+Basic
+=====
+
+"foobar"
+
+---
+
+(source_file (string_double))
+
+========================
+Escape unicode no braces
+========================
+
+"foo\u001abar"
+
+---
+
+(source_file (string_double (string_escape)))
+
+=====================
+Escape unicode braces
+=====================
+
+"foo\u{1f574}bar"
+
+---
+
+(source_file (string_double (string_escape)))
+
+============
+Escape quote
+============
+
+"foo\"bar"
+
+---
+
+(source_file (string_double (string_escape)))

--- a/grammar/tree-sitter-rcl/test/corpus/string.txt
+++ b/grammar/tree-sitter-rcl/test/corpus/string.txt
@@ -92,3 +92,13 @@ Answer: {42}.
   (string
     (fstring_triple
       (string_hole (number (num_decimal))))))
+
+==========================
+String with comment inside
+==========================
+
+" // A comment inside a string is not a comment. "
+
+---
+
+(source_file (string (string_double)))

--- a/grammar/tree-sitter-rcl/test/corpus/string.txt
+++ b/grammar/tree-sitter-rcl/test/corpus/string.txt
@@ -62,3 +62,33 @@ But three does:
 ---
 
 (source_file (string (string_triple (string_escape))))
+
+===============
+f-string single
+===============
+
+f"Part \{ <- escape { "real hole" } end"
+
+---
+
+(source_file
+  (string
+    (fstring_double
+      (string_escape)
+      (string_hole
+        (string (string_double))))))
+
+===============
+f-string triple
+===============
+
+f"""
+Answer: {42}.
+"""
+
+---
+
+(source_file
+  (string
+    (fstring_triple
+      (string_hole (number (num_decimal))))))

--- a/grammar/tree-sitter-rcl/test/corpus/type.txt
+++ b/grammar/tree-sitter-rcl/test/corpus/type.txt
@@ -1,0 +1,111 @@
+====
+Term
+====
+
+let i: Int = q; i
+
+---
+
+(source_file
+  (expr_stmt
+    (stmt_let
+      ident: (ident)
+      type: (type_term (ident))
+      value: (ident))
+    (ident)))
+
+===========
+Apply 1 arg
+===========
+
+let i: List[Int] = q; i
+
+---
+
+(source_file
+  (expr_stmt
+    (stmt_let
+      ident: (ident)
+      type:
+        (type_apply
+          name: (type_term (ident))
+          args: (type_term (ident)))
+      value: (ident))
+    (ident)))
+
+============
+Apply 2 args
+============
+
+let i: Dict[Int, Null] = q; i
+
+---
+
+(source_file
+  (expr_stmt
+    (stmt_let
+      ident: (ident)
+      type:
+        (type_apply
+          name: (type_term (ident))
+          args: (type_term (ident))
+          args: (type_term (ident)))
+      value: (ident))
+    (ident)))
+
+===============
+Function 0 args
+===============
+
+let i: () -> Int = q; i
+
+---
+
+(source_file
+  (expr_stmt
+    (stmt_let
+      ident: (ident)
+      type:
+        (type_function
+          result: (type_term (ident)))
+      value: (ident))
+    (ident)))
+
+==============
+Function 1 arg
+==============
+
+let i: (Bool) -> Int = q; i
+
+---
+
+(source_file
+  (expr_stmt
+    (stmt_let
+      ident: (ident)
+      type:
+        (type_function
+          args: (type_term (ident))
+          result: (type_term (ident)))
+      value: (ident))
+    (ident)))
+
+===============
+Function 2 args
+===============
+
+let i: (Bool, Int) -> Int = q; i
+
+---
+
+(source_file
+  (expr_stmt
+    (stmt_let
+      ident: (ident)
+      type:
+        (type_function
+          args: (type_term (ident))
+          args: (type_term (ident))
+          result: (type_term (ident)))
+      value: (ident))
+    (ident)))

--- a/grammar/tree-sitter-rcl/test/corpus/type.txt
+++ b/grammar/tree-sitter-rcl/test/corpus/type.txt
@@ -53,6 +53,23 @@ let i: Dict[Int, Null] = q; i
       value: (ident))
     (ident)))
 
+============
+Apply 0 args
+============
+
+let i: Void[] = q; i
+
+---
+
+(source_file
+  (expr_stmt
+    (stmt_let
+      ident: (ident)
+      type:
+        (type_apply name: (type_term (ident)))
+      value: (ident))
+    (ident)))
+
 ===============
 Function 0 args
 ===============

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -45,3 +45,4 @@ nav:
       - "rcl query": "rcl_query.md"
   - "Development":
       - "Testing": "testing.md"
+      - "Tree-sitter": "tree_sitter.md"

--- a/src/cst.rs
+++ b/src/cst.rs
@@ -280,6 +280,10 @@ pub enum Expr {
     },
 
     /// A binary operator.
+    // TODO: We might also break up the binop into a true binary operator with
+    // two sides, e.g. `<=` and `==`, and into n-ary operators that can be
+    // repeated such as `+` and `*`. The latter would have a vec of args while
+    // the former would have just the two sides.
     BinOp {
         // TODO: How to handle noncode in binops? It is somewhat reasonable to
         // expect people to write


### PR DESCRIPTION
Tree-sitter is a parser generator, it’s parsers can be used by Helix, Neovim, and GitHub Linguist. It would also be nice to have a fault-tolerant parser to include in the wasm module to do syntax highlighting on the demo page.

* [x] Implement the grammar.
* [x] Fuzz the generated parser against the hand-written one.
* [x] Test if it can be used in Helix.

### Example

With some configuration that I should probably save somewhere, Helix is now able to highlight RCL:

<img width="600px" src="https://github.com/ruuda/rcl/assets/506953/e7d6bb3a-5d73-4c43-a616-a7c19641170b" alt="Helix highlighting RCL"/>
