### PR TITLE
Add an intermediate stage for `pprint` with markup

### DIFF
--- a/fuzz/fuzz_targets/main.rs
+++ b/fuzz/fuzz_targets/main.rs
@@ -107,9 +107,7 @@ fn run_fmt(loader: &mut Loader, input: &str, cfg: &pprint::Config) -> Result<Str
     let id = loader.load_string(input.to_string());
     let cst = loader.get_cst(id)?;
     let doc = rcl::fmt_cst::format_expr(input, &cst);
-    let mut out = String::new();
-    doc.println(cfg).write_string_no_markup(&mut out);
-    Ok(out)
+    Ok(doc.println(cfg).to_string_no_markup())
 }
 
 /// Run the formatter twice and check for idempotency.
@@ -138,15 +136,13 @@ fn fuzz_eval_json_idempotent(loader: &mut Loader, input: &str, cfg: pprint::Conf
     let full_span = loader.get_span(doc_1);
     let json = rcl::fmt_json::format_json(full_span, &val_1)?;
 
-    let mut out_1 = String::new();
-    json.println(&cfg).write_string_no_markup(&mut out_1);
+    let out_1 = json.println(&cfg).to_string_no_markup();
     let doc_2 = loader.load_string(out_1);
     let val_2 = loader.evaluate(&mut type_env, &mut value_env, doc_2, &mut tracer)?;
 
     let full_span = loader.get_span(doc_2);
     let json = rcl::fmt_json::format_json(full_span, &val_2)?;
-    let mut out_2 = String::new();
-    json.println(&cfg).write_string_no_markup(&mut out_2);
+    let out_2 = json.println(&cfg).to_string_no_markup();
 
     assert_eq!(
         loader.get_doc(doc_2).data,
@@ -163,8 +159,7 @@ fn fuzz_eval_json_idempotent(loader: &mut Loader, input: &str, cfg: pprint::Conf
 fn fuzz_eval_json_check(loader: &mut Loader, input: &str, cfg: pprint::Config) -> Result<()> {
     let (full_span, value) = eval(loader, input)?;
     let json_doc = rcl::fmt_json::format_json(full_span, &value)?;
-    let mut json_str = String::new();
-    json_doc.println(&cfg).write_string_no_markup(&mut json_str);
+    let json_str = json_doc.println(&cfg).to_string_no_markup();
     match serde_json::from_str::<serde_json::Value>(&json_str[..]) {
         Ok(..) => Ok(()),
         Err(err) => panic!("RCL output should be parseable, but got {err:?}"),
@@ -177,8 +172,7 @@ fn fuzz_eval_json_check(loader: &mut Loader, input: &str, cfg: pprint::Config) -
 fn fuzz_eval_toml_check(loader: &mut Loader, input: &str, cfg: pprint::Config) -> Result<()> {
     let (full_span, value) = eval(loader, input)?;
     let toml_doc = rcl::fmt_toml::format_toml(full_span, &value)?;
-    let mut toml_str = String::new();
-    toml_doc.println(&cfg).write_string_no_markup(&mut toml_str);
+    let toml_str = toml_doc.println(&cfg).to_string_no_markup();
     match toml::from_str::<toml::Value>(&toml_str[..]) {
         Ok(..) => Ok(()),
         Err(err) => panic!("RCL output should be parseable, but got {err:?}"),

--- a/fuzz/fuzz_targets/main.rs
+++ b/fuzz/fuzz_targets/main.rs
@@ -6,7 +6,6 @@ use libfuzzer_sys::fuzz_target;
 use rcl::error::Result;
 use rcl::eval::Evaluator;
 use rcl::loader::{Loader, VoidFilesystem};
-use rcl::markup::MarkupMode;
 use rcl::pprint;
 use rcl::runtime::Value;
 use rcl::source::Span;
@@ -108,8 +107,9 @@ fn run_fmt(loader: &mut Loader, input: &str, cfg: &pprint::Config) -> Result<Str
     let id = loader.load_string(input.to_string());
     let cst = loader.get_cst(id)?;
     let doc = rcl::fmt_cst::format_expr(input, &cst);
-    let result = doc.println(cfg);
-    Ok(result)
+    let mut out = String::new();
+    doc.println(cfg).write_string_no_markup(&mut out);
+    Ok(out)
 }
 
 /// Run the formatter twice and check for idempotency.
@@ -138,13 +138,15 @@ fn fuzz_eval_json_idempotent(loader: &mut Loader, input: &str, cfg: pprint::Conf
     let full_span = loader.get_span(doc_1);
     let json = rcl::fmt_json::format_json(full_span, &val_1)?;
 
-    let out_1 = json.println(&cfg);
+    let mut out_1 = String::new();
+    json.println(&cfg).write_string_no_markup(&mut out_1);
     let doc_2 = loader.load_string(out_1);
     let val_2 = loader.evaluate(&mut type_env, &mut value_env, doc_2, &mut tracer)?;
 
     let full_span = loader.get_span(doc_2);
     let json = rcl::fmt_json::format_json(full_span, &val_2)?;
-    let out_2 = json.println(&cfg);
+    let mut out_2 = String::new();
+    json.println(&cfg).write_string_no_markup(&mut out_2);
 
     assert_eq!(
         loader.get_doc(doc_2).data,
@@ -161,7 +163,8 @@ fn fuzz_eval_json_idempotent(loader: &mut Loader, input: &str, cfg: pprint::Conf
 fn fuzz_eval_json_check(loader: &mut Loader, input: &str, cfg: pprint::Config) -> Result<()> {
     let (full_span, value) = eval(loader, input)?;
     let json_doc = rcl::fmt_json::format_json(full_span, &value)?;
-    let json_str = json_doc.println(&cfg);
+    let mut json_str = String::new();
+    json_doc.println(&cfg).write_string_no_markup(&mut json_str);
     match serde_json::from_str::<serde_json::Value>(&json_str[..]) {
         Ok(..) => Ok(()),
         Err(err) => panic!("RCL output should be parseable, but got {err:?}"),
@@ -174,7 +177,8 @@ fn fuzz_eval_json_check(loader: &mut Loader, input: &str, cfg: pprint::Config) -
 fn fuzz_eval_toml_check(loader: &mut Loader, input: &str, cfg: pprint::Config) -> Result<()> {
     let (full_span, value) = eval(loader, input)?;
     let toml_doc = rcl::fmt_toml::format_toml(full_span, &value)?;
-    let toml_str = toml_doc.println(&cfg);
+    let mut toml_str = String::new();
+    toml_doc.println(&cfg).write_string_no_markup(&mut toml_str);
     match toml::from_str::<toml::Value>(&toml_str[..]) {
         Ok(..) => Ok(()),
         Err(err) => panic!("RCL output should be parseable, but got {err:?}"),
@@ -182,10 +186,7 @@ fn fuzz_eval_toml_check(loader: &mut Loader, input: &str, cfg: pprint::Config) -
 }
 
 fn fuzz_main(loader: &mut Loader, input: Input) -> Result<()> {
-    let mut cfg = pprint::Config {
-        width: 80,
-        markup: MarkupMode::None,
-    };
+    let mut cfg = pprint::Config { width: 80 };
     match input.mode {
         Mode::Lex => {
             let doc = loader.load_string(input.data.to_string());
@@ -237,10 +238,7 @@ fuzz_target!(|input: Input| {
     if let Err(err) = result {
         let inputs = loader.as_inputs();
         let err_doc = err.report(&inputs);
-        let cfg = pprint::Config {
-            width: 80,
-            markup: MarkupMode::Ansi,
-        };
+        let cfg = pprint::Config { width: 80 };
         let _ = err_doc.println(&cfg);
     }
 });

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -474,11 +474,7 @@ mod test {
         let args_vec: Vec<_> = args.iter().map(|a| a.to_string()).collect();
         let err = super::parse(args_vec).err().unwrap();
         let cfg = Config { width: 80 };
-        let mut out = String::new();
-        err.report(&[])
-            .println(&cfg)
-            .write_string_no_markup(&mut out);
-        out
+        err.report(&[]).println(&cfg).to_string_no_markup()
     }
 
     fn parse(args: &[&'static str]) -> (GlobalOptions, Cmd) {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -473,11 +473,12 @@ mod test {
     fn fail_parse(args: &[&'static str]) -> String {
         let args_vec: Vec<_> = args.iter().map(|a| a.to_string()).collect();
         let err = super::parse(args_vec).err().unwrap();
-        let cfg = Config {
-            width: 80,
-            markup: MarkupMode::None,
-        };
-        err.report(&[]).println(&cfg)
+        let cfg = Config { width: 80 };
+        let mut out = String::new();
+        err.report(&[])
+            .println(&cfg)
+            .write_string_no_markup(&mut out);
+        out
     }
 
     fn parse(args: &[&'static str]) -> (GlobalOptions, Cmd) {

--- a/src/error.rs
+++ b/src/error.rs
@@ -201,7 +201,7 @@ impl Error {
         // TODO: Find a prettier way to report the value path of an error.
         // For now this will do.
         if self.path.is_empty() {
-            return Doc::empty();
+            return Doc::Empty;
         }
         let mut path_doc = vec![Doc::from("in value"), Doc::HardBreak];
         for elem in self.path.iter().rev() {

--- a/src/fmt_cst.rs
+++ b/src/fmt_cst.rs
@@ -70,7 +70,7 @@ impl<'a> Formatter<'a> {
     /// only one soft break.
     pub fn soft_break_if_not_empty<T>(&self, elems: &[T]) -> Doc<'a> {
         if elems.is_empty() {
-            Doc::empty()
+            Doc::Empty
         } else {
             Doc::SoftBreak
         }
@@ -499,7 +499,7 @@ impl<'a> Formatter<'a> {
                 // but only rarely are there multiple seqs in the collection.
                 // If there is suffix noncode, then we need the separator before
                 // it, otherwise we would output a syntax error.
-                _ if elements.len() == 1 && suffix.is_empty() => Doc::empty(),
+                _ if elements.len() == 1 && suffix.is_empty() => Doc::Empty,
                 _ if is_last => Doc::tall(sep_str),
                 _ => Doc::str(sep_str),
             };

--- a/src/fmt_toml.rs
+++ b/src/fmt_toml.rs
@@ -192,7 +192,7 @@ impl Formatter {
 
     /// Format a dict as (top-level) table body.
     fn table<'a>(&mut self, vs: impl Iterator<Item = (&'a Value, &'a Value)>) -> Result<Doc<'a>> {
-        let mut doc = Doc::empty();
+        let mut doc = Doc::Empty;
         for (k, v) in vs {
             doc = doc + self.key_value(k, v)?;
         }

--- a/src/markup.rs
+++ b/src/markup.rs
@@ -107,6 +107,8 @@ pub fn switch_ansi(markup: Markup) -> &'static str {
 /// A string pieced together from fragments that have markup.
 pub struct MarkupString<'a> {
     fragments: Vec<(&'a str, Markup)>,
+    // TODO: We could keep track of the length, then to_string could preallocate
+    // a buffer of the right size.
 }
 
 impl<'a> MarkupString<'a> {
@@ -151,10 +153,18 @@ impl<'a> MarkupString<'a> {
     }
 
     /// Append the string to a regular `String`, discarding all markup.
+    #[inline]
     pub fn write_string_no_markup(&self, out: &mut String) {
         for (frag_str, _markup) in self.fragments.iter() {
             out.push_str(frag_str);
         }
+    }
+
+    /// Append the string to a regular `String`, discarding all markup.
+    pub fn to_string_no_markup(&self) -> String {
+        let mut out = String::new();
+        self.write_string_no_markup(&mut out);
+        out
     }
 
     /// Write the string to a writer, discarding all markup.

--- a/src/pprint.rs
+++ b/src/pprint.rs
@@ -676,9 +676,7 @@ mod test {
 
     fn print_width(doc: &Doc, width: u32) -> String {
         let config = Config { width };
-        let mut out = String::new();
-        doc.println(&config).write_string_no_markup(&mut out);
-        out
+        doc.println(&config).to_string_no_markup()
     }
 
     #[test]

--- a/src/pprint.rs
+++ b/src/pprint.rs
@@ -16,7 +16,7 @@
 //!
 //! [wadler2003]: https://homepages.inf.ed.ac.uk/wadler/papers/prettier/prettier.pdf
 
-use crate::markup::{Markup, MarkupMode};
+use crate::markup::{Markup, MarkupString};
 use crate::pprint::printer::{PrintResult, Printer};
 
 /// Whether to format a node in wide mode or tall mode.
@@ -31,9 +31,6 @@ pub struct Config {
     /// The pretty printer will try to avoid creating lines longer than `width`
     /// columns, but this is not always possible.
     pub width: u32,
-
-    /// How to output color and other markup hints.
-    pub markup: MarkupMode,
 }
 
 /// A document tree that can be pretty-printed.
@@ -289,7 +286,7 @@ impl<'a> Doc<'a> {
     }
 
     /// Print the document to the given printer.
-    fn print_to(&self, printer: &mut Printer, mode: Mode) -> PrintResult {
+    fn print_to(&'a self, printer: &mut Printer<'a>, mode: Mode) -> PrintResult {
         match self {
             Doc::Str { content, width } => printer.push_str(content, *width),
             Doc::String { content, width } => printer.push_str(content, *width),
@@ -299,7 +296,7 @@ impl<'a> Doc<'a> {
             },
             Doc::Sep => match mode {
                 Mode::Tall => printer.newline(),
-                Mode::Wide => printer.push_char(' '),
+                Mode::Wide => printer.push_str(" ", 1),
             },
             Doc::SoftBreak => match mode {
                 Mode::Tall => printer.newline(),
@@ -354,8 +351,11 @@ impl<'a> Doc<'a> {
     }
 
     /// Pretty-print the document. Ensure the document ends in a newline.
-    pub fn println(&self, config: &Config) -> String {
-        let mut printer = Printer::new(config);
+    pub fn println<'s>(&'s self, config: &'s Config) -> MarkupString<'a>
+    where
+        's: 'a,
+    {
+        let mut printer: Printer<'a> = Printer::new(config);
         self.print_to(&mut printer, Mode::Tall);
         printer.flush_newline();
         printer.into_inner()
@@ -444,7 +444,8 @@ pub(crate) use flush_indent;
 /// This is a separate module to be able to hide some of the printer internals
 /// from the [`Doc::println`] implementation.
 mod printer {
-    use super::{Config, Markup, MarkupMode};
+    use super::Config;
+    use crate::markup::{Markup, MarkupString};
 
     /// Whether printing in a particular mode fitted or not.
     ///
@@ -465,9 +466,9 @@ mod printer {
     }
 
     /// Helper for pretty-printing documents that tracks indentation state.
-    pub struct Printer {
+    pub struct Printer<'a> {
         /// Buffer where we place the output.
-        out: String,
+        out: MarkupString<'a>,
 
         /// Target width that we should try to not exceed.
         width: u32,
@@ -482,39 +483,35 @@ mod printer {
         needs_indent: bool,
 
         /// The currently applied markup.
-        markup: Option<Markup>,
-
-        /// How to apply markup.
-        markup_mode: MarkupMode,
+        markup: Markup,
     }
 
-    impl Printer {
+    impl<'a> Printer<'a> {
         /// Create a new printer with the given line width target.
         pub fn new(config: &Config) -> Printer {
             Printer {
-                out: String::new(),
+                out: MarkupString::new(),
                 width: config.width,
                 line_width: 0,
                 indent: 0,
                 needs_indent: true,
-                markup: None,
-                markup_mode: config.markup,
+                markup: Markup::None,
             }
         }
 
         /// Return the result string printed to the printer.
-        pub fn into_inner(self) -> String {
+        pub fn into_inner(self) -> MarkupString<'a> {
             self.out
         }
 
         /// Execute `f` against this printer. If the result was too wide, roll back.
-        pub fn try_<F: FnOnce(&mut Printer) -> PrintResult>(&mut self, f: F) -> PrintResult {
-            let len = self.out.len();
+        pub fn try_<F: FnOnce(&mut Printer<'a>) -> PrintResult>(&mut self, f: F) -> PrintResult {
+            let fragment_len = self.out.num_fragments();
             let line_width = self.line_width;
             let needs_indent = self.needs_indent;
             let result = f(self);
             if result.is_overflow() {
-                self.out.truncate(len);
+                self.out.truncate(fragment_len);
                 self.line_width = line_width;
                 self.needs_indent = needs_indent;
             }
@@ -522,7 +519,10 @@ mod printer {
         }
 
         /// Execute `f` under increased indentation width.
-        pub fn indented<F: FnOnce(&mut Printer) -> PrintResult>(&mut self, f: F) -> PrintResult {
+        pub fn indented<F: FnOnce(&mut Printer<'a>) -> PrintResult>(
+            &mut self,
+            f: F,
+        ) -> PrintResult {
             self.indent += 2;
             let result = f(self);
             self.indent -= 2;
@@ -530,20 +530,15 @@ mod printer {
         }
 
         /// Execute `f` with markup applied.
-        pub fn with_markup<F: FnOnce(&mut Printer) -> PrintResult>(
+        pub fn with_markup<F: FnOnce(&mut Printer<'a>) -> PrintResult>(
             &mut self,
             markup: Markup,
             f: F,
         ) -> PrintResult {
             let prev = self.markup;
-            let next = Some(markup);
-            let switch_on = self.markup_mode.get_switch(prev, next);
-            let switch_off = self.markup_mode.get_switch(next, prev);
-            self.out.push_str(switch_on);
-            self.markup = next;
+            self.markup = markup;
             let result = f(self);
             self.markup = prev;
-            self.out.push_str(switch_off);
             result
         }
 
@@ -559,7 +554,7 @@ mod printer {
             let mut n_left = self.indent as usize;
             while n_left > 0 {
                 let n = n_left.min(spaces.len());
-                self.out.push_str(&spaces[..n]);
+                self.out.push(&spaces[..n], Markup::None);
                 n_left -= n;
             }
 
@@ -576,7 +571,7 @@ mod printer {
             }
         }
 
-        pub fn push_str(&mut self, value: &str, width: u32) -> PrintResult {
+        pub fn push_str(&mut self, value: &'a str, width: u32) -> PrintResult {
             debug_assert!(
                 !value.contains('\n'),
                 // coverage:off -- Error not expected to be hit.
@@ -584,16 +579,8 @@ mod printer {
                 // coverage:on
             );
             self.write_indent();
-            self.out.push_str(value);
+            self.out.push(value, self.markup);
             self.line_width += width;
-            self.fits()
-        }
-
-        pub fn push_char(&mut self, ch: char) -> PrintResult {
-            debug_assert_ne!(ch, '\n', "Use `newline` to push a newline instead.");
-            self.write_indent();
-            self.out.push(ch);
-            self.line_width += 1;
             self.fits()
         }
 
@@ -614,9 +601,9 @@ mod printer {
             // not emitting space after e.g. a multi-line `let` binding. We work
             // around this hack in string literals by escaping trailing spaces,
             // which is arguably better anyway for visibility.
-            self.out.truncate(self.out.trim_end_matches(' ').len());
+            self.out.trim_spaces_end();
 
-            self.out.push('\n');
+            self.out.push("\n", Markup::None);
             self.line_width = 0;
             self.needs_indent = true;
             // For the print result, we measure until the end of the line, so a
@@ -649,13 +636,13 @@ mod printer {
 
 #[cfg(test)]
 mod test {
-    use super::{Config, Doc, MarkupMode};
+    use super::{Config, Doc};
 
     fn print_width(doc: &Doc, width: u32) -> String {
-        doc.println(&Config {
-            width,
-            markup: MarkupMode::None,
-        })
+        let config = Config { width };
+        let mut out = String::new();
+        doc.println(&config).write_string_no_markup(&mut out);
+        out
     }
 
     #[test]

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -28,9 +28,7 @@ fn rcl_evaluate_impl<'a>(
     // TODO: Make output format configurable.
     let json = rcl::fmt_json::format_json(full_span, &value)?;
     // TODO: Print to colored DOM nodes.
-    let mut out = String::new();
-    json.println(print_cfg).write_string_no_markup(&mut out);
-    Ok(out)
+    Ok(json.println(print_cfg).to_string_no_markup())
 }
 
 #[wasm_bindgen]
@@ -45,9 +43,7 @@ pub fn rcl_evaluate(input: &str) -> std::result::Result<String, String> {
         Err(err) => {
             let inputs = loader.as_inputs();
             let err_doc = err.report(&inputs);
-            let mut err_str = String::new();
-            err_doc.println(&cfg).write_string_no_markup(&mut err_str);
-            Err(err_str)
+            Err(err_doc.println(&cfg).to_string_no_markup())
         }
     }
 }


### PR DESCRIPTION
### Background

Currently to go from a `Doc` to a `String`, the formatter also splices in any ANSI escape codes for markup. The output of formatting a `Doc` is always a `String`.

For the WASM module, for the web output I do want to run the pretty-printer to compute indents, but I don’t want escape sequences, I need a list of spans with markup, so I can convert them into html `<span>` elements.

So introduce an intermediate stage, `MarkupString`, which is a list of string slices with markup. The representation is awful: formatting produces many tiny strings that are much smaller than the 24 bytes that a `(&str, Markup)` takes. But a quick but not very thorough measurement shows this has virtually no impact on evaluation time of a large json document.

As a drive-by, add an optimization in the pretty-printer to early out if the document gets too wide and we know we need to switch to tall already. This change _does_ have a small but measurable impact.

### To do

* [x] Ensure test coverage.
* [x] Run fuzzer for a while.