### PR TITLE
Output colored spans in wasm, add more output modes

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -190,7 +190,12 @@
             cargoLock.lockFile = ./Cargo.lock;
             buildAndTestSubdir = "wasm";
             doCheck = false; # We already test the non-wasm build.
-            nativeBuildInputs = [ rustWasm pkgs.wasm-bindgen-cli pkgs.binaryen ];
+            nativeBuildInputs = [
+              pkgs.binaryen
+              pkgs.esbuild
+              pkgs.wasm-bindgen-cli
+              rustWasm
+            ];
 
             buildPhase =
               ''
@@ -210,6 +215,9 @@
                 --target no-modules \
                 --no-typescript \
                 target/rcl.wasm
+
+              cat ${./wasm/src/rcl_dom.js} $out/rcl.js | esbuild --minify > $out/bundle.js
+              mv $out/bundle.js $out/rcl.js
               '';
             installPhase = "echo 'Skipping default install phase.'";
           };
@@ -223,6 +231,7 @@
                 # cached version that does not depend on our patched pygments.
                 pkgs.python311Packages.black
                 pkgs.binaryen
+                pkgs.esbuild
                 pkgs.maturin
                 pkgs.nodejs  # Required for tree-sitter.
                 pkgs.rustup

--- a/golden/error_json/non_string_key.test
+++ b/golden/error_json/non_string_key.test
@@ -8,4 +8,6 @@ stdin:1:1
   ╷
 1 │ {
   ╵ ^
+in value
+at key 1
 Error: To export as json, keys must be strings.

--- a/src/fmt_json.rs
+++ b/src/fmt_json.rs
@@ -85,12 +85,11 @@ impl Formatter {
                 elements.push(",".into());
                 elements.push(Doc::Sep);
             }
+            self.path.push(PathElement::Key(k.clone()));
             match k {
                 Value::String(k_str) => {
-                    self.path.push(PathElement::Key(k.clone()));
                     elements.push(self.string(k_str).with_markup(Markup::Field))
                 }
-                // TODO: Include information about the encountered type.
                 _ => return self.error("To export as json, keys must be strings."),
             };
             elements.push(": ".into());

--- a/src/markup.rs
+++ b/src/markup.rs
@@ -109,7 +109,7 @@ pub fn switch_ansi(markup: Markup) -> &'static str {
 
 /// A string pieced together from fragments that have markup.
 pub struct MarkupString<'a> {
-    fragments: Vec<(&'a str, Markup)>,
+    pub fragments: Vec<(&'a str, Markup)>,
     // TODO: We could keep track of the length, then to_string could preallocate
     // a buffer of the right size.
 }

--- a/wasm/README.md
+++ b/wasm/README.md
@@ -63,6 +63,11 @@ Generate the Javascript bindings:
       --no-typescript \
       target/rcl.wasm
 
+Concatenate the required source files (“bundling”) and minify them if desired:
+
+    cat wasm/src/rcl_dom.js target/web/rcl.js | esbuild --minify > target/web/bundle.js
+    mv target/web/{bundle,rcl}.js
+
 Put everything together:
 
     cp wasm/index.html target/web

--- a/wasm/index.html
+++ b/wasm/index.html
@@ -3,7 +3,7 @@
     <meta charset="utf-8">
     <title>RCL WASM Demo</title>
     <script src='/rcl.js' async></script>
-    <script type="module">
+    <script>
       window.onload = function() {
         const { rcl_evaluate } = wasm_bindgen;
         async function run() {
@@ -12,14 +12,9 @@
           const output_box = document.getElementById("output");
           input_box.addEventListener("input", (evt) => {
             const input = evt.target.value;
-            console.log(input);
-            var output = "";
-            try {
-              output = rcl_evaluate(input_box.textContent);
-            } catch (err) {
-              output = err;
-            }
-            output_box.textContent = output;
+            const out_node = document.createElement("code");
+            rcl_evaluate(input_box.textContent, out_node);
+            output_box.replaceChild(out_node, output_box.firstChild);
           });
         }
         run();
@@ -35,6 +30,10 @@
         border: 1pt solid #ddd;
         white-space: pre;
       }
+      code .error { font-weight: bold; color: red; }
+      code .warning { font-weight: bold; color: darkgoldenrod; }
+      code .field { color: blue; }
+      code .string { color: cyan; }
     </style>
   </head>
   <body>
@@ -42,10 +41,10 @@
     <h2>Input</h2>
     <p id="input" contenteditable="true" plaintext-only="true">[for x in std.range(0, 3): { id = x, name = f"item-{x}" }]</p>
     <h2>Output</h2>
-    <p id="output">[
+    <p id="output"><code>[
   {"id": 0, "name": "item-0"},
   {"id": 1, "name": "item-1"},
   {"id": 2, "name": "item-2"}
-]</p>
+]</code></p>
   </body>
 </html>

--- a/wasm/index.html
+++ b/wasm/index.html
@@ -5,7 +5,11 @@
     <script src='/rcl.js' async></script>
     <script>
       window.onload = function() {
-        const { rcl_evaluate } = wasm_bindgen;
+        const {
+          rcl_evaluate_json,
+          rcl_evaluate_query_value,
+          rcl_evaluate_query,
+        } = wasm_bindgen;
         async function run() {
           await wasm_bindgen();
           const input_box = document.getElementById("input");
@@ -13,7 +17,9 @@
           input_box.addEventListener("input", (evt) => {
             const input = evt.target.value;
             const out_node = document.createElement("code");
-            rcl_evaluate(input_box.textContent, out_node);
+            const out_width = 60;
+            const max_len = 5000;
+            rcl_evaluate_json(input_box.textContent, out_node, out_width, max_len);
             output_box.replaceChild(out_node, output_box.firstChild);
           });
         }

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -5,6 +5,10 @@
 // you may not use this file except in compliance with the License.
 // A copy of the License has been included in the root of the repository.
 
+// Needed to silence the `module = ...` attribute in the extern import,
+// due to limitations in wasm-bindgen.
+#![allow(unused_variables)]
+
 use rcl::error::Result;
 use rcl::eval::Evaluator;
 use rcl::loader::{Loader, VoidFilesystem};
@@ -17,6 +21,7 @@ use wasm_bindgen::prelude::wasm_bindgen;
 extern "C" {
     pub type Node;
 
+    #[wasm_bindgen(module = "rcl_dom.js")]
     fn append_span(node: &Node, class: &str, text: &str);
 }
 

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -8,15 +8,56 @@
 use rcl::error::Result;
 use rcl::eval::Evaluator;
 use rcl::loader::{Loader, VoidFilesystem};
-use rcl::pprint;
+use rcl::markup::Markup;
+use rcl::pprint::{self, Doc};
 use rcl::tracer::VoidTracer;
 use wasm_bindgen::prelude::wasm_bindgen;
 
-fn rcl_evaluate_impl<'a>(
-    loader: &'a mut Loader,
-    print_cfg: &pprint::Config,
-    input: &'a str,
-) -> Result<String> {
+#[wasm_bindgen]
+extern "C" {
+    pub type Node;
+
+    fn append_span(node: &Node, class: &str, text: &str);
+}
+
+/// Return the class name for a markup span in the output.
+fn markup_class(markup: Markup) -> &'static str {
+    match markup {
+        Markup::Builtin => "builtin",
+        Markup::Comment => "comment",
+        Markup::Error => "error",
+        Markup::Escape => "escape",
+        Markup::Field => "field",
+        Markup::Highlight => "highlight",
+        Markup::Keyword => "keyword",
+        Markup::None => "text",
+        Markup::Number => "number",
+        Markup::String => "string",
+        Markup::Trace => "trace",
+        Markup::Type => "type",
+        Markup::Warning => "warning",
+    }
+}
+
+/// Pretty-print a document, append it as DOM nodes.
+fn pprint_doc(doc: Doc, out_node: &Node) {
+    // TODO: Make the print width configurable.
+    let cfg = pprint::Config { width: 60 };
+    let markup_string = doc.println(&cfg);
+    let mut markup = Markup::None;
+    let mut buffer = String::new();
+    for (f_str, f_markup) in markup_string.fragments.iter() {
+        if markup != *f_markup {
+            append_span(out_node, markup_class(markup), &buffer);
+            buffer.clear();
+            markup = *f_markup;
+        }
+        buffer.push_str(f_str);
+    }
+    append_span(out_node, markup_class(markup), &buffer);
+}
+
+fn rcl_evaluate_impl<'a>(loader: &'a mut Loader, input: &'a str, out_node: &Node) -> Result<()> {
     loader.set_filesystem(Box::new(VoidFilesystem));
     let id = loader.load_string(input.to_string());
     let mut tracer = VoidTracer;
@@ -26,24 +67,18 @@ fn rcl_evaluate_impl<'a>(
     let value = evaluator.eval_doc(&mut type_env, &mut value_env, id)?;
     let full_span = loader.get_span(id);
     // TODO: Make output format configurable.
-    let json = rcl::fmt_json::format_json(full_span, &value)?;
-    // TODO: Print to colored DOM nodes.
-    Ok(json.println(print_cfg).to_string_no_markup())
+    let doc = rcl::fmt_json::format_json(full_span, &value)?;
+    pprint_doc(doc, out_node);
+    Ok(())
 }
 
 #[wasm_bindgen]
-pub fn rcl_evaluate(input: &str) -> std::result::Result<String, String> {
+pub fn rcl_evaluate(input: &str, out_node: &Node) {
     let mut loader = Loader::new();
-    let cfg = pprint::Config {
-        // TODO: Make this configurable.
-        width: 60,
-    };
-    match rcl_evaluate_impl(&mut loader, &cfg, input) {
-        Ok(string) => Ok(string),
-        Err(err) => {
-            let inputs = loader.as_inputs();
-            let err_doc = err.report(&inputs);
-            Err(err_doc.println(&cfg).to_string_no_markup())
-        }
+    let result = rcl_evaluate_impl(&mut loader, input, out_node);
+    if let Err(err) = result {
+        let inputs = loader.as_inputs();
+        let err_doc = err.report(&inputs);
+        pprint_doc(err_doc, out_node);
     }
 }

--- a/wasm/src/rcl_dom.js
+++ b/wasm/src/rcl_dom.js
@@ -11,7 +11,14 @@ function append_span(node, class_, text) {
   } else {
     const span = document.createElement("span");
     span.className = class_;
-    span.append(text);
+    // In error messages we use box drawing characters, but Chromium
+    // does not display the long one in the correct weight, so replace
+    // it with a normal pipe, which renders better.
+    span.append(
+      (class_ === "error") || (class_ === "warning")
+      ? text.replace("│", "|")
+      : text
+    );
     node.appendChild(span);
   }
 }

--- a/wasm/src/rcl_dom.js
+++ b/wasm/src/rcl_dom.js
@@ -1,0 +1,17 @@
+// RCL -- A reasonable configuration language.
+// Copyright 2024 Ruud van Asseldonk
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// A copy of the License has been included in the root of the repository.
+
+function append_span(node, class_, text) {
+  if (class_ === "text") {
+    node.append(text);
+  } else {
+    const span = document.createElement("span");
+    span.className = class_;
+    span.append(text);
+    node.appendChild(span);
+  }
+}


### PR DESCRIPTION
This will be used to power the live demo on an upcoming webpage. Define an extern function to append a span with a given class, and then to output colored text from wasm, we call that function repeatedly.