### PR TITLE
Improve formatting of chained expressions

### DIFF
--- a/golden/fmt/chain_atomic.test
+++ b/golden/fmt/chain_atomic.test
@@ -2,10 +2,11 @@ let x = very_long_base.very_long_field.another_long_field.call_func().list[32].e
 x
 
 # output:
-let x = foo_bar_baz
-  .bar_foo_baz
-  .very_long_field_name
+let x = very_long_base
+  .very_long_field
+  .another_long_field
   .call_func()
   .list[32]
   .entry["key"]
   .call_again();
+x

--- a/golden/fmt/chain_atomic.test
+++ b/golden/fmt/chain_atomic.test
@@ -1,0 +1,11 @@
+let x = very_long_base.very_long_field.another_long_field.call_func().list[32].entry["key"].call_again();
+x
+
+# output:
+let x = foo_bar_baz
+  .bar_foo_baz
+  .very_long_field_name
+  .call_func()
+  .list[32]
+  .entry["key"]
+  .call_again();

--- a/golden/fmt/seq_atomic.test
+++ b/golden/fmt/seq_atomic.test
@@ -1,0 +1,42 @@
+// Here we test that the seq elements get formatted either wide or tall.
+let oneline = [for x in xs: for y in ys: for z in zs: x + y + z];
+
+let multiline = [
+  for x in xs:
+  for y in ys:
+  for z in zs:
+  for w in ws:
+  x + y + z + w
+];
+
+let multiline_tall = [
+  for x in xs:
+  for y in ys:
+  for z in zs:
+  for u in us:
+  for v in vs:
+  for w in ws:
+  x + y + z + u + v + w
+];
+
+[oneline, multiline, multiline_tall]
+
+# output:
+// Here we test that the seq elements get formatted either wide or tall.
+let oneline = [for x in xs: for y in ys: for z in zs: x + y + z];
+
+let multiline = [
+  for x in xs: for y in ys: for z in zs: for w in ws: x + y + z + w
+];
+
+let multiline_tall = [
+  for x in xs:
+  for y in ys:
+  for z in zs:
+  for u in us:
+  for v in vs:
+  for w in ws:
+  x + y + z + u + v + w
+];
+
+[oneline, multiline, multiline_tall]

--- a/src/fmt_cst.rs
+++ b/src/fmt_cst.rs
@@ -495,7 +495,7 @@ impl<'a> Formatter<'a> {
     pub fn seqs(&self, elements: &[Prefixed<Seq>], suffix: &[NonCode]) -> Doc<'a> {
         let mut result = Vec::new();
         for (i, elem) in elements.iter().enumerate() {
-            let (elem_doc, sep_str) = self.seq(&elem.inner);
+            let elem_doc = self.seq(&elem.inner);
 
             // We wrap the inner Seq in a group, so you can have a collection
             // that consists of multiple comprehensions, and each one fits on
@@ -513,8 +513,8 @@ impl<'a> Formatter<'a> {
                 // If there is suffix noncode, then we need the separator before
                 // it, otherwise we would output a syntax error.
                 _ if elements.len() == 1 && suffix.is_empty() => Doc::Empty,
-                _ if is_last => Doc::tall(sep_str),
-                _ => Doc::str(sep_str),
+                _ if is_last => Doc::tall(","),
+                _ => Doc::str(","),
             };
             result.push(sep_doc);
 
@@ -534,33 +534,28 @@ impl<'a> Formatter<'a> {
         Doc::Concat(result)
     }
 
-    /// Format a sequence. Return that and the trailing separator.
-    pub fn seq(&self, seq: &Seq) -> (Doc<'a>, &'static str) {
+    /// Format a sequence.
+    pub fn seq(&self, seq: &Seq) -> Doc<'a> {
         match seq {
-            Seq::Elem { value, .. } => (self.expr(value), ","),
+            Seq::Elem { value, .. } => self.expr(value),
 
             Seq::AssocExpr { field, value, .. } => {
                 // TODO: Special-case an inner string for markup?
-                (
-                    concat! { self.expr(field).with_markup(Markup::Field) ": " self.expr(value) },
-                    ",",
-                )
+                concat! { self.expr(field).with_markup(Markup::Field) ": " self.expr(value) }
             }
 
-            Seq::AssocIdent { field, value, .. } => (
-                concat! { self.span(*field).with_markup(Markup::Field) " = " self.expr(value) },
-                ",",
-            ),
+            Seq::AssocIdent { field, value, .. } => {
+                concat! { self.span(*field).with_markup(Markup::Field) " = " self.expr(value) }
+            }
 
             Seq::Stmt { stmt, body, .. } => {
-                let (body_doc, sep) = self.seq(&body.inner);
-                let result = concat! {
+                let body_doc = self.seq(&body.inner);
+                concat! {
                     self.stmt(stmt)
                     Doc::Sep
                     self.non_code(&body.prefix)
                     body_doc
-                };
-                (result, sep)
+                }
             }
 
             Seq::For {
@@ -569,8 +564,8 @@ impl<'a> Formatter<'a> {
                 body,
                 ..
             } => {
-                let (body_doc, sep) = self.seq(&body.inner);
-                let result = concat! {
+                let body_doc = self.seq(&body.inner);
+                concat! {
                     Doc::str("for").with_markup(Markup::Keyword)
                     " "
                     // TODO: This does not use a proper sep, which means we
@@ -588,15 +583,14 @@ impl<'a> Formatter<'a> {
                     Doc::Sep
                     self.non_code(&body.prefix)
                     body_doc
-                };
-                (result, sep)
+                }
             }
 
             Seq::If {
                 condition, body, ..
             } => {
-                let (body_doc, sep) = self.seq(&body.inner);
-                let result = concat! {
+                let body_doc = self.seq(&body.inner);
+                concat! {
                     Doc::str("if").with_markup(Markup::Keyword)
                     " "
                     self.expr(condition)
@@ -604,8 +598,7 @@ impl<'a> Formatter<'a> {
                     Doc::Sep
                     self.non_code(&body.prefix)
                     body_doc
-                };
-                (result, sep)
+                }
             }
         }
     }

--- a/src/fmt_cst.rs
+++ b/src/fmt_cst.rs
@@ -10,7 +10,7 @@
 //! The formatter converts the CST into a [`Doc`], which can subsequently be
 //! pretty-printed for formatting.
 
-use crate::cst::{Expr, NonCode, Prefixed, Seq, Stmt, StringPart, Type};
+use crate::cst::{Chain, Expr, NonCode, Prefixed, Seq, Stmt, StringPart, Type};
 use crate::lexer::{QuoteStyle, StringPrefix};
 use crate::markup::Markup;
 use crate::pprint::{concat, flush_indent, group, indent, Doc};
@@ -363,15 +363,6 @@ impl<'a> Formatter<'a> {
 
             Expr::Var(span) => self.span(*span),
 
-            // TODO: Parse as vec with multiple dots, so we can toggle an entire
-            // method chain as all-or-nothing wide or tall. For now, we just
-            // don't line-wrap field access.
-            Expr::Field { inner, field, .. } => {
-                concat! {
-                    self.expr(inner) "." self.span(*field)
-                }
-            }
-
             Expr::IfThenElse {
                 condition,
                 then_body,
@@ -426,46 +417,6 @@ impl<'a> Formatter<'a> {
                 }
             }
 
-            Expr::Call {
-                function,
-                args,
-                suffix,
-                ..
-            } => {
-                concat! {
-                    self.expr(function)
-                    group! {
-                        "("
-                        Doc::SoftBreak
-                        indent! {
-                            Doc::join(
-                                args.iter().map(|(_span, arg)| self.prefixed_expr(arg)),
-                                concat!{ "," Doc::Sep },
-                            )
-                            Doc::tall(",")
-                            Doc::SoftBreak
-                            self.non_code(suffix)
-                        }
-                        ")"
-                    }
-                }
-            }
-
-            Expr::Index {
-                collection, index, ..
-            } => {
-                concat! {
-                    self.expr(collection)
-                    group! {
-                        "["
-                        Doc::SoftBreak
-                        indent! { self.prefixed_expr(index) }
-                        Doc::SoftBreak
-                        "]"
-                    }
-                }
-            }
-
             Expr::UnOp { op_span, body, .. } => {
                 concat! {
                     self.span(*op_span)
@@ -489,7 +440,66 @@ impl<'a> Formatter<'a> {
                     }
                 }
             }
+
+            Expr::Chain {
+                base_expr, chain, ..
+            } => self.chain(base_expr, chain),
         }
+    }
+
+    /// Format a chained expression.
+    pub fn chain(&self, base: &Expr, chain: &[(Span, Chain)]) -> Doc<'a> {
+        // Every field should start a new line. When we have a call or index,
+        // before the first field they go on the base, afterward they go on
+        // "next", the part after base. The "next" part needs to be indented
+        // but the base part is not.
+        let mut group_base = Vec::new();
+        let mut group_next = Vec::new();
+        let mut group = &mut group_base;
+
+        group.push(self.expr(base));
+
+        for (_, chain_elem) in chain.iter() {
+            match chain_elem {
+                Chain::Field { field } => {
+                    group = &mut group_next;
+                    group.push(Doc::SoftBreak);
+                    group.push(".".into());
+                    group.push(self.span(*field));
+                }
+                Chain::Call { args, suffix, .. } => {
+                    let call_doc = group! {
+                        "("
+                        Doc::SoftBreak
+                        indent! {
+                            Doc::join(
+                                args.iter().map(|(_span, arg)| self.prefixed_expr(arg)),
+                                concat!{ "," Doc::Sep },
+                            )
+                            Doc::tall(",")
+                            Doc::SoftBreak
+                            self.non_code(suffix)
+                        }
+                        ")"
+                    };
+                    group.push(call_doc);
+                }
+
+                Chain::Index { index, .. } => {
+                    let index_doc = group! {
+                        "["
+                        Doc::SoftBreak
+                        indent! { self.prefixed_expr(index) }
+                        Doc::SoftBreak
+                        "]"
+                    };
+                    group.push(index_doc);
+                }
+            }
+        }
+
+        group_base.push(indent! { Doc::Concat(group_next) });
+        group! { Doc::Concat(group_base) }
     }
 
     pub fn seqs(&self, elements: &[Prefixed<Seq>], suffix: &[NonCode]) -> Doc<'a> {


### PR DESCRIPTION
### Summary

When there is a chain of expressions, e.g. `a.b.c.f().g[1]`, when it is long, we want to break it over lines such that every `.` starts on a new line. The entire chain should either be wide or tall. Currently this is not how it works, chains are wide only, although function calls and indexing can cause a line break. This causes some formatting to be suboptimal.

To achieve this, change the CST (but not the AST) to make "a chain of expressions" a first-class node. This is already how the parser worked, so that fits very naturally. Then in the abstractor we convert the vec into a degenerate tree (linked list) of nested nodes, so that the evaluator and typechecker can remain unchanged.

### Testing

 * [x] Confirm test coverage
 * [x] Ensure fuzzer finds no new errors

### Future work

 * Do the same for chains of statements, so that a chain of let-bindings either all goes on the same line or all on different lines.
 * Same for binary (or really n-ary) operators.

In both cases the solution will be similar, make it a list in the CST instead of a degenerate tree.