### PR TITLE
Implement `--check` option for `rcl format`

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -19,9 +19,10 @@ compatibility impact will be clearly marked as such in the changelog.
 Unreleased.
 
  * Add [union types](types.md#union-types).
- * The [`--in-place`](rcl_format.md#-i-in-place) option for `rcl format` is now
-   implemented.
-* The webassembly module can now output colored spans.
+ * `rcl format` now supports [`--in-place`](rcl_format.md#-i-in-place) and
+   [`--check`](rcl_format.md#-check). These were documented but marked to-do
+   previously, now they are fully supported.
+ * The webassembly module can now output colored spans.
 
 ## 0.2.0
 

--- a/docs/rcl_format.md
+++ b/docs/rcl_format.md
@@ -11,27 +11,37 @@ Shorthands:
 
 Read an <abbr>RCL</abbr> expression from `<file>` and format it according to the
 standard style. When `<file>` is `-`, read from stdin. When no files are
-specified, the input defaults to stdin. Print the result to stdout, unless
-`--in-place` is used.
+specified, the input defaults to stdin.
+
+In the default mode, there must be exactly one input file, and the formatted
+result is printed to stdout. With `--in-place` and `--check`, you can provide
+multiple input files.
 
 ## Options
 
-### `-c` `--check`
+### `--check`
 
-TODO: This option currently does not exist, but it should. It should make the
-program exit with code 1 if formatting is incorrect.
+Report whether any files would be reformatted. If so, exit with exit code 1.
+When all files are already formatted correctly, exit with exit code 0. This
+can be used on <abbr>CI</abbr> or in a Git pre-commit hook to ensure that
+<abbr>RCL</abbr> files are formatted in the standard style.
+
+When this option is used, the command accepts multiple input files. This option
+is incompatible with `--in-place`.
 
 ### `-i` `--in-place`
 
-Instead of printing to stdout, rewrite files in-place. When this option is used,
-the command accepts multiple input files. Without this option, there must be
-exactly one input file.
+Instead of printing to stdout, rewrite files in-place.
+
+When this option is used, the command accepts multiple input files. This option
+is incompatible with `--check`.
 
 ### `-o` `--output <outfile>`
 
 Write the output to the given file instead of stdout. When [`--directory`][dir]
-is set, the output path is relative to that directory. This option is
-incompatible with `--in-place`.
+is set, the output path is relative to that directory.
+
+This option is incompatible with `--check` and `--in-place`.
 
 [dir]: rcl.md#-c-directory-dir
 

--- a/fuzz/dictionary_cli.txt
+++ b/fuzz/dictionary_cli.txt
@@ -6,11 +6,12 @@
 "query"
 
 # Options
+"--check"
 "--color"
 "--directory"
+"--format"
 "--help"
 "--in-place"
-"--format"
 "--sandbox"
 "--version"
 "--width"


### PR DESCRIPTION
I want to check that the examples are formatted correctly on CI, so let’s have a `--check` mode to verify formatting. It doesn’t print the diff, because computing diffs is not trivial, and in practice you can just run `rcl format --in-place` and run `git diff` to see what changed. Maybe in the future we could report the line number of the first mismatch, but for now just printing which files have errors is probably good enough.