### PR TITLE
Make the autoformatter suitable for serious usage

### DIFF
--- a/examples/buckets.rcl
+++ b/examples/buckets.rcl
@@ -1,13 +1,10 @@
 // See docs/tutorial.md for the origin of this example.
 {
   buckets = [
-    let retention_days = {
-      hourly = 4,
-      daily = 30,
-      monthly = 365,
-    };
+    let retention_days = { hourly = 4, daily = 30, monthly = 365 };
     for database in ["alpha", "bravo"]:
-    for period, days in retention_days: {
+    for period, days in retention_days:
+    {
       name = f"{database}-{period}",
       region = "eu-west",
       lifecycle_policy = { delete_after_seconds = days * 24 * 3600 },

--- a/examples/github_actions.rcl
+++ b/examples/github_actions.rcl
@@ -1,19 +1,13 @@
 {
   name = "Build",
 
-  on = {
-    push = { branches = ["master"] },
-    workflow_dispatch = {},
-  },
+  on = { push = { branches = ["master"] }, workflow_dispatch = {} },
 
   jobs = {
     "Build": {
       runs-on = "ubuntu-22.04",
       steps = [
-        {
-          name = "Checkout",
-          uses = "actions/checkout@v3.5.3",
-        },
+        { name = "Checkout", uses = "actions/checkout@v3.5.3" },
         {
           name = "Install Nix",
           uses = "cachix/install-nix-action@v18",

--- a/examples/tags.rcl
+++ b/examples/tags.rcl
@@ -49,5 +49,5 @@ let var = {
       tag
     };
     host: group_tags | device_tags
-  }
+  },
 }

--- a/flake.nix
+++ b/flake.nix
@@ -322,6 +322,13 @@
                 touch $out
                 '';
 
+              fmtRcl = pkgs.runCommand
+                "check-fmt-rcl"
+                { buildInputs = [ debugBuild ]; }
+                ''
+                rcl format --check ${./examples}/* | tee $out
+                '';
+
               typecheckPython = pkgs.runCommand
                 "check-typecheck-python"
                 { buildInputs = [ pythonEnv ]; }

--- a/fuzz/fuzz_targets/fuzz_source.rs
+++ b/fuzz/fuzz_targets/fuzz_source.rs
@@ -59,6 +59,7 @@ impl<'a> Arbitrary<'a> for Input<'a> {
             b"j" => Mode::EvalJsonIdempotent { width },
             b"k" => Mode::EvalJsonCheck { width },
             b"t" => Mode::EvalTomlCheck { width },
+            b"f" => Mode::EvalFormat { width },
             _ => return Err(Error::IncorrectFormat),
         };
 

--- a/fuzz/src/smith.rs
+++ b/fuzz/src/smith.rs
@@ -185,6 +185,8 @@ define_ops! {
     0xe3 => ModeJsonCheck,
     /// Set the check mode to `TomlCheck`.
     0xe4 => ModeTomlCheck,
+    /// Set the check mode to `EvalFormat`.
+    0xe5 => ModeEvalFormat,
 }
 
 /// A helper for visualizing program execution for debug purposes.
@@ -528,6 +530,9 @@ impl<'a> ProgramBuilder<'a> {
             }
             Op::ModeTomlCheck => {
                 self.mode = Mode::EvalTomlCheck { width: n as u32 };
+            }
+            Op::ModeEvalFormat => {
+                self.mode = Mode::EvalFormat { width: n as u32 };
             }
         }
 

--- a/golden/error/runtime_fstring_not_formattable.test
+++ b/golden/error/runtime_fstring_not_formattable.test
@@ -7,4 +7,4 @@ stdin:1:33
   ╵                                 ^~~~~~~~~~~~~~~~
 Error: This value cannot be interpolated into a string:
 
-  Dict.contains
+  «method Dict.contains»

--- a/golden/error/type_index_fn.test
+++ b/golden/error/type_index_fn.test
@@ -8,10 +8,10 @@ stdin:4:4
   ╷
 4 │ xs[x => x]
   ╵    ^~~~~~
-Error: Dict does not have a key «function».
+Error: Dict does not have a key «function 0:119..125».
 
 stdin:4:1
   ╷
 4 │ xs[x => x]
   ╵ ^~
-Note: On value: { «function»: 0 }
+Note: On value: { «function 0:91..97»: 0 }

--- a/golden/fmt/collections_sep.test
+++ b/golden/fmt/collections_sep.test
@@ -1,0 +1,44 @@
+// This tests where to insert spaces in collection literals.
+
+// Plain lists and sets should get no spaces around them.
+let xs = [1, 2, 3];
+let ys = {1, 2, 3};
+
+// Dicts should get spaces around them, regardless of json or record style.
+let xs = { a = 1, b = 2 };
+let ys = { "a": 1, "b": 2 };
+
+// List comprehensions never get spaces.
+let xs = [for x in xs: x * 2];
+
+// For consistency, set comprehensions do not either.
+let ys = {for y in ys: y * 2};
+
+// But dict comprehensions do for consistency with dicts.
+let xs = { for x in xs: name = x };
+let ys = { for y in ys: "name": y };
+
+null
+
+# output:
+// This tests where to insert spaces in collection literals.
+
+// Plain lists and sets should get no spaces around them.
+let xs = [1, 2, 3];
+let ys = {1, 2, 3};
+
+// Dicts should get spaces around them, regardless of json or record style.
+let xs = { a = 1, b = 2 };
+let ys = { "a": 1, "b": 2 };
+
+// List comprehensions never get spaces.
+let xs = [for x in xs: x * 2];
+
+// For consistency, set comprehensions do not either.
+let ys = {for y in ys: y * 2};
+
+// But dict comprehensions do for consistency with dicts.
+let xs = { for x in xs: name = x };
+let ys = { for y in ys: "name": y };
+
+null

--- a/golden/fmt/fstring.test
+++ b/golden/fmt/fstring.test
@@ -31,7 +31,7 @@ let x = f"This f-string has {"a hole"} inside it.";
 
 let y = f"This f-string has {[
   // A list with a comment.
-  "in a hole"
+  "in a hole",
 ]} inside it.";
 
 // The next one is a regression test; a bug would drop the content after the

--- a/golden/fmt/function.test
+++ b/golden/fmt/function.test
@@ -75,7 +75,9 @@ let doc2 = (
 
 let with_lets = (widgets, frobnicators) =>
   let frobnicated_widgets = [
-    for widget in widgets: for frobnicator in frobnicators: frobnicator(widget)
+    for widget in widgets:
+    for frobnicator in frobnicators:
+    frobnicator(widget)
   ];
   [for w in frobnicated_widgets: w.turbo_encabulator];
 

--- a/golden/fmt/json_dict.test
+++ b/golden/fmt/json_dict.test
@@ -9,7 +9,7 @@ let tall = {
 wide | tall
 
 # output:
-let wide = {"a": 1, "b": 2};
+let wide = { "a": 1, "b": 2 };
 let tall = {
   // The comment forces tall mode.
   "a": 1,

--- a/golden/fmt/list_comprehension.test
+++ b/golden/fmt/list_comprehension.test
@@ -5,16 +5,21 @@ let tall = [
   let marzlevanes =
     x.hydrocoptics.marzlevanes; marzlevanes,
 ];
-let wide = [for x in tall: if x.active_on_tuesday(): x.inner];
+
+// The depth of the comprehension matters. Even if it would fit,
+// we format those deeper than 2 as tall.
+let wide = [for x in tall_long_if_active_on_tuesday(): x.inner];
+let tall = [for x in tall: if x.active_on_tuesday(): x.inner];
+
 // The next one demonstrates that we should be able to have two comprehensions
 // in a collection, and if the comprehension itself fits, it should not
 // line-wrap.
 let double_comprehension = [
-  for m in extract_marzlevanes():
-  if m.is_hydrocoptic():
+  for m in extract_marzlevanes()
+    .is_hydrocoptic():
   m.frobnicated(),
-  for h in extract_hydrocoptics():
-  if h.is_marzlevane():
+  for h in extract_hydrocoptics()
+    .is_marzlevane():
   h.frobnicated(),
 ];
 // TODO: All-or-nothing let chain wide or tall.
@@ -31,13 +36,22 @@ let tall = [
   let marzlevanes = x.hydrocoptics.marzlevanes;
   marzlevanes
 ];
-let wide = [for x in tall: if x.active_on_tuesday(): x.inner];
+
+// The depth of the comprehension matters. Even if it would fit,
+// we format those deeper than 2 as tall.
+let wide = [for x in tall_long_if_active_on_tuesday(): x.inner];
+let tall = [
+  for x in tall:
+  if x.active_on_tuesday():
+  x.inner
+];
+
 // The next one demonstrates that we should be able to have two comprehensions
 // in a collection, and if the comprehension itself fits, it should not
 // line-wrap.
 let double_comprehension = [
-  for m in extract_marzlevanes(): if m.is_hydrocoptic(): m.frobnicated(),
-  for h in extract_hydrocoptics(): if h.is_marzlevane(): h.frobnicated(),
+  for m in extract_marzlevanes().is_hydrocoptic(): m.frobnicated(),
+  for h in extract_hydrocoptics().is_marzlevane(): h.frobnicated(),
 ];
 // TODO: All-or-nothing let chain wide or tall.
 let b = [1]; a + b

--- a/golden/fmt/seq_atomic.test
+++ b/golden/fmt/seq_atomic.test
@@ -1,21 +1,25 @@
 // Here we test that the seq elements get formatted either wide or tall.
-let oneline = [for x in xs: for y in ys: for z in zs: x + y + z];
+let oneline = [
+  for x in xs
+    .some_long_field
+    .some_long_field
+    .some_long_field:
+  x
+];
 
 let multiline = [
-  for x in xs:
-  for y in ys:
-  for z in zs:
-  for w in ws:
-  x + y + z + w
+  for x in xs
+    .some_long_field
+    .some_long_field
+    .more_long_field
+    .some_long_field:
+  x
 ];
 
 let multiline_tall = [
-  for x in xs:
-  for y in ys:
-  for z in zs:
-  for u in us:
-  for v in vs:
-  for w in ws:
+  for x in xs: for y in ys:
+  for z in zs: for u in us:
+  for v in vs: for w in ws:
   x + y + z + u + v + w
 ];
 
@@ -23,10 +27,10 @@ let multiline_tall = [
 
 # output:
 // Here we test that the seq elements get formatted either wide or tall.
-let oneline = [for x in xs: for y in ys: for z in zs: x + y + z];
+let oneline = [for x in xs.some_long_field.some_long_field.some_long_field: x];
 
 let multiline = [
-  for x in xs: for y in ys: for z in zs: for w in ws: x + y + z + w
+  for x in xs.some_long_field.some_long_field.more_long_field.some_long_field: x
 ];
 
 let multiline_tall = [

--- a/golden/fmt/unop.test
+++ b/golden/fmt/unop.test
@@ -1,8 +1,17 @@
+let x =
 not
 not
 not
 not
-true
+true;
+
+let y =- 32;
+
+null
 
 # output:
-not not not not true
+let x = not not not not true;
+
+let y = -32;
+
+null

--- a/golden/rcl/builtin_function_fmt.test
+++ b/golden/rcl/builtin_function_fmt.test
@@ -1,0 +1,9 @@
+// This is a regression test to test that the value formatter formats built-in
+// functions in the same way that the CST formatter does, including line breaks.
+{ some_really_long_key_name_that_causes_the_rest_to_wrap_if_long_enough = std.read_file_utf8 }
+
+# output:
+{
+  some_really_long_key_name_that_causes_the_rest_to_wrap_if_long_enough = std
+    .read_file_utf8,
+}

--- a/golden/rcl/builtin_method.test
+++ b/golden/rcl/builtin_method.test
@@ -1,4 +1,4 @@
 "abc".len
 
 # output:
-String.len
+«method String.len»

--- a/golden/rcl/function.test
+++ b/golden/rcl/function.test
@@ -1,4 +1,4 @@
 (arg1, arg2) => arg1 + arg2
 
 # output:
-«function»
+«function 0:0..28»

--- a/src/cst.rs
+++ b/src/cst.rs
@@ -346,6 +346,25 @@ pub enum Seq {
     },
 }
 
+impl Seq {
+    /// Whether the innermost seq is `Seq::Elem` (as opposed to `AssocExpr` or `AssocIdent`).
+    pub fn is_inner_elem(&self) -> bool {
+        match self {
+            Seq::Elem { .. } => true,
+            Seq::AssocIdent { .. } => false,
+            Seq::AssocExpr { .. } => false,
+            Seq::For { body, .. } => body.inner.is_inner_elem(),
+            Seq::If { body, .. } => body.inner.is_inner_elem(),
+            Seq::Stmt { body, .. } => body.inner.is_inner_elem(),
+        }
+    }
+
+    /// Whether this is a comprehension (as opposed to `Seq::Elem` or `Assoc{Expr,Ident}`).
+    pub fn is_comprehension(&self) -> bool {
+        matches!(self, Seq::For { .. } | Seq::If { .. } | Seq::Stmt { .. })
+    }
+}
+
 /// A case in a chained non-operator expression (field lookup, call, index).
 #[derive(Debug)]
 pub enum Chain {

--- a/src/cst.rs
+++ b/src/cst.rs
@@ -351,8 +351,7 @@ impl Seq {
     pub fn is_inner_elem(&self) -> bool {
         match self {
             Seq::Elem { .. } => true,
-            Seq::AssocIdent { .. } => false,
-            Seq::AssocExpr { .. } => false,
+            Seq::AssocExpr { .. } | Seq::AssocIdent { .. } => false,
             Seq::For { body, .. } => body.inner.is_inner_elem(),
             Seq::If { body, .. } => body.inner.is_inner_elem(),
             Seq::Stmt { body, .. } => body.inner.is_inner_elem(),
@@ -362,6 +361,16 @@ impl Seq {
     /// Whether this is a comprehension (as opposed to `Seq::Elem` or `Assoc{Expr,Ident}`).
     pub fn is_comprehension(&self) -> bool {
         matches!(self, Seq::For { .. } | Seq::If { .. } | Seq::Stmt { .. })
+    }
+
+    /// Return the number of layers, where the innermost expression has depth 1.
+    pub fn depth(&self) -> u32 {
+        match self {
+            Seq::Elem { .. } | Seq::AssocIdent { .. } | Seq::AssocExpr { .. } => 1,
+            Seq::For { body, .. } => 1 + body.inner.depth(),
+            Seq::If { body, .. } => 1 + body.inner.depth(),
+            Seq::Stmt { body, .. } => 1 + body.inner.depth(),
+        }
     }
 }
 

--- a/src/fmt_cst.rs
+++ b/src/fmt_cst.rs
@@ -10,6 +10,7 @@
 //! The formatter converts the CST into a [`Doc`], which can subsequently be
 //! pretty-printed for formatting.
 
+use crate::ast::UnOp;
 use crate::cst::{Chain, Expr, NonCode, Prefixed, Seq, Stmt, StringPart, Type};
 use crate::lexer::{QuoteStyle, StringPrefix};
 use crate::markup::Markup;
@@ -420,13 +421,16 @@ impl<'a> Formatter<'a> {
                 }
             }
 
-            Expr::UnOp { op_span, body, .. } => {
-                concat! {
-                    self.span(*op_span)
-                    Doc::Sep
+            Expr::UnOp { op, body, .. } => match op {
+                UnOp::Neg => concat! {
+                    "-" self.expr(body)
+                },
+                UnOp::Not => concat! {
+                    Doc::from("not").with_markup(Markup::Keyword)
+                    " "
                     self.expr(body)
-                }
-            }
+                },
+            },
 
             // TODO: Make this a collection in the parser, so we can toggle
             // operator chains into all-wide or all-tall but not mixed.

--- a/src/fmt_cst.rs
+++ b/src/fmt_cst.rs
@@ -571,6 +571,16 @@ impl<'a> Formatter<'a> {
 
     /// Format a sequence.
     pub fn seq(&self, seq: &Seq) -> Doc<'a> {
+        // If we have a deep seq, even though it *could* fit on one line,
+        // this is a complex thing akin to a nested for loop, usually it gets
+        // more readable if we spread it across multiple lines. So if the seq
+        // is deeper than 2, force it to be tall.
+        let sep = if seq.depth() > 2 {
+            Doc::HardBreak
+        } else {
+            Doc::Sep
+        };
+
         match seq {
             Seq::Elem { value, .. } => self.expr(value),
 
@@ -587,7 +597,7 @@ impl<'a> Formatter<'a> {
                 let body_doc = self.seq(&body.inner);
                 concat! {
                     self.stmt(stmt)
-                    Doc::Sep
+                    sep
                     self.non_code(&body.prefix)
                     body_doc
                 }
@@ -615,7 +625,7 @@ impl<'a> Formatter<'a> {
                     " "
                     self.expr(collection)
                     ":"
-                    Doc::Sep
+                    sep
                     self.non_code(&body.prefix)
                     body_doc
                 }
@@ -630,7 +640,7 @@ impl<'a> Formatter<'a> {
                     " "
                     self.expr(condition)
                     ":"
-                    Doc::Sep
+                    sep
                     self.non_code(&body.prefix)
                     body_doc
                 }

--- a/src/fmt_cst.rs
+++ b/src/fmt_cst.rs
@@ -516,13 +516,18 @@ impl<'a> Formatter<'a> {
 
             let is_last = i + 1 == elements.len();
             let sep_doc = match i {
-                // For collections that contain a single seq, do not add a
-                // separator, even when they are multi-line. It makes
+                // For collections that contain a single comprehension, do not
+                // add a separator, even when they are multi-line. It makes
                 // comprehensions look weird, which are regularly multi-line
                 // but only rarely are there multiple seqs in the collection.
                 // If there is suffix noncode, then we need the separator before
                 // it, otherwise we would output a syntax error.
-                _ if elements.len() == 1 && suffix.is_empty() => Doc::Empty,
+                _ if elements.len() == 1 && suffix.is_empty() => match elements[0].inner {
+                    Seq::Elem { .. } | Seq::AssocExpr { .. } | Seq::AssocIdent { .. } => {
+                        Doc::tall(",")
+                    }
+                    Seq::For { .. } | Seq::If { .. } | Seq::Stmt { .. } => Doc::Empty,
+                },
                 _ if is_last => Doc::tall(","),
                 _ => Doc::str(","),
             };

--- a/src/pprint.rs
+++ b/src/pprint.rs
@@ -407,6 +407,18 @@ impl<'a> From<String> for Doc<'a> {
     }
 }
 
+impl<'a, T> From<Option<T>> for Doc<'a>
+where
+    Doc<'a>: From<T>,
+{
+    fn from(value: Option<T>) -> Doc<'a> {
+        match value {
+            None => Doc::Empty,
+            Some(x) => Doc::from(x),
+        }
+    }
+}
+
 impl<'a> std::ops::Add<Doc<'a>> for Doc<'a> {
     type Output = Doc<'a>;
 


### PR DESCRIPTION
Previously the autoformatter worked fine, and all the pretty-print machinery is quite advanced and robust, but the actual output left some things to be desired, in particular spacing around key-value pairs, chained expressions (fixed in #53), and also it tended to put things on a line when that fits, which does not necessarily make things more readable.

This addresses those shortcomings to the point where I think the formatter now works well enough for real-world files that it is usable in practice.

Furthermore, add a fuzzer to verify the property that `format ∘ evaluate(format=rcl) = evaluate(format=rcl)`; in other words, the value pretty-printer and the CST pretty-printer (the autoformatter) format things in exactly the same way. The fuzzer uncovered some differences at first, but at the time of writing it didn’t find any new counterexamples for over an hour.

To do in a follow-up PR:

 * Format let-chains (or statements in general) as one per line.
 * Format binary (n-ary) expressions as one wide/tall group, don’t allow breaking in the middle.