### PR TITLE
Add support for magic trailing comma in the formatter

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -18,11 +18,26 @@ compatibility impact will be clearly marked as such in the changelog.
 
 Unreleased.
 
+**Changes with compatibility impact:**
+
+* The output of the formatter can differ significantly. This may cause large
+  diffs in codebases where formatting is enforced. See below for more details.
+
+All changes:
+
  * Add [union types](types.md#union-types).
+ * The formatter now handles real-world code much better. In particular, it no
+   longer puts things on one line as aggressively, it improves how chains of
+   field lookups and method calls get line-wrapped, and the formatting of
+   dictionaries is now consistent between `evaluate` and `format` output (both
+   now use inner padding).
  * `rcl format` now supports [`--in-place`](rcl_format.md#-i-in-place) and
    [`--check`](rcl_format.md#-check). These were documented but marked to-do
    previously, now they are fully supported.
  * The webassembly module can now output colored spans.
+
+Independent of this release, <abbr>RCL</abbr> now has an official website:
+<https://rcl-lang.org>.
 
 ## 0.2.0
 

--- a/docs/rcl_format.md
+++ b/docs/rcl_format.md
@@ -16,7 +16,6 @@ specified, the input defaults to stdin.
 In the default mode, there must be exactly one input file, and the formatted
 result is printed to stdout. With `--in-place` and `--check`, you can provide
 multiple input files.
-
 ## Options
 
 ### `--check`
@@ -49,3 +48,34 @@ This option is incompatible with `--check` and `--in-place`.
 
 Target width in columns. Must be an integer. Defaults to 80. Note that the
 formatter is not always able to stay within the desired width limit.
+
+## The standard style
+
+The output of `rcl format` should generally be sensible and readable, though as
+with any mechanical formatter, it cannot please everybody for every possible
+input. The format is not configurable aside from the target [width](#-w-width-width).
+Although the formatter tries to not exceed the target width, it is not always
+possible to stay within the limit.
+
+The formatter is not sensitive to initial formatting, with the exception of
+trailing commas, to give some control over how collections are formatted.[^1]
+Collections with at least two elements that have a trailing comma will be
+formatted tall, even when they fit on a line. To format the collection wide,
+remove the trailing comma. This applies to any place where trailing commas are
+allowed, not just collection literals.
+
+```rcl
+// This collection is formatted wide.
+let xs = [1, 2];
+
+// Even though it fits on one line, this collection is kept tall due to the
+// trailing comma.
+let ys = [
+  1,
+  2,
+];
+```
+
+[^1]: This was inspired by how the Black Python formatter
+      [treats trailing trailing commas][magic-comma].
+[magic-comma]: https://black.readthedocs.io/en/stable/the_black_code_style/current_style.html#the-magic-trailing-comma

--- a/examples/github_actions.rcl
+++ b/examples/github_actions.rcl
@@ -1,13 +1,19 @@
 {
   name = "Build",
 
-  on = { push = { branches = ["master"] }, workflow_dispatch = {} },
+  on = {
+    push = { branches = ["master"] },
+    workflow_dispatch = {},
+  },
 
   jobs = {
     "Build": {
       runs-on = "ubuntu-22.04",
       steps = [
-        { name = "Checkout", uses = "actions/checkout@v3.5.3" },
+        {
+          name = "Checkout",
+          uses = "actions/checkout@v3.5.3",
+        },
         {
           name = "Install Nix",
           uses = "cachix/install-nix-action@v18",

--- a/golden/fmt/call_multiline.test
+++ b/golden/fmt/call_multiline.test
@@ -1,4 +1,5 @@
-let x = f( a, b , c,);
+let x1 = f( a, b , c);
+let x2 = f( a, b , c,);
 let y = f(
   // The first argument.
   a,
@@ -7,7 +8,12 @@ let y = f(
 x + y
 
 # output:
-let x = f(a, b, c);
+let x1 = f(a, b, c);
+let x2 = f(
+  a,
+  b,
+  c,
+);
 let y = f(
   // The first argument.
   a,

--- a/golden/fmt/comment_before_close.test
+++ b/golden/fmt/comment_before_close.test
@@ -21,6 +21,14 @@ let f = (
   // And in an argument list, it should be preserved.
 ) => x;
 
+let u0: Union[
+  // Also in types.
+] = null;
+let u1: Union[
+  Int,
+  // Whether or not there is an element before it.
+] = null;
+
 null
 
 # output:
@@ -46,5 +54,13 @@ let f = (
   x,
   // And in an argument list, it should be preserved.
 ) => x;
+
+let u0: Union[,
+  // Also in types.
+] = null;
+let u1: Union[
+  Int,
+  // Whether or not there is an element before it.
+] = null;
 
 null

--- a/golden/fmt/function.test
+++ b/golden/fmt/function.test
@@ -2,7 +2,9 @@ let f =
  (
  ) => "short value";
 
-let g1 = (arg1, arg2,) => [very_long_name_1, very_long_name_2, very_long_name_3, very_long_name_4, very_long_name_5];
+let g1 = (
+arg1,
+arg2) => [very_long_name_1, very_long_name_2, very_long_name_3, very_long_name_4, very_long_name_5];
 let g2 = (rec_self, k) =>
   if {0, 1}.contains(k):
     1
@@ -21,7 +23,7 @@ let doc2 = (
   arg1,
 
   // Argument 2.
-  arg2,
+  arg2
 ) => 42;
 
 let with_lets = (widgets, frobnicators) =>

--- a/golden/fmt/magic_trailing_comma.test
+++ b/golden/fmt/magic_trailing_comma.test
@@ -1,0 +1,150 @@
+// RCL implements Black's "magic trailing comma" behavior for lists of length >= 2.
+// https://black.readthedocs.io/en/stable/the_black_code_style/current_style.html#the-magic-trailing-comma
+// If there is a trailing comma originally, and there are at least two elements,
+// then the output is tall regardless of whether it would fit wide. If there is
+// no trailing comma, the output is whatever fits.
+
+// Length 1, trailing comma is not relevant.
+let a = [1,];
+let b = [1];
+let c = [
+  1
+];
+let d = [
+  1,
+];
+
+// Length 2, trailing comma forces tall.
+let a = [1, 2];
+let b = [
+  1, 2
+];
+let c = [1, 2,];
+let d = [
+  1, 2,
+];
+
+// Sets.
+let z = {1,};
+let a = {1, 2};
+let b = {
+  1, 2
+};
+let c = {1, 2,};
+let d = {
+  1, 2,
+};
+
+// Dicts.
+let z = {a=1,};
+let a = {a=1, b=2};
+let b = {
+  a=1, b=2
+};
+let c = {a=1, b=2,};
+let d = {
+  a=1, b=2,
+};
+
+// Function calls.
+let z = f(1,);
+let a = f(1, 2);
+let b = f(
+  1, 2
+);
+let c = f(1, 2,);
+let d = f(
+  1, 2,
+);
+
+// Function definitions.
+let z = (x,) => 1;
+let a = (x, y) => 1;
+let b = (
+  x, y
+) => 1;
+let c = (x, y,) => 1;
+let d = (
+  x, y,
+) => 1;
+
+null
+
+# output:
+// RCL implements Black's "magic trailing comma" behavior for lists of length >= 2.
+// https://black.readthedocs.io/en/stable/the_black_code_style/current_style.html#the-magic-trailing-comma
+// If there is a trailing comma originally, and there are at least two elements,
+// then the output is tall regardless of whether it would fit wide. If there is
+// no trailing comma, the output is whatever fits.
+
+// Length 1, trailing comma is not relevant.
+let a = [1];
+let b = [1];
+let c = [1];
+let d = [1];
+
+// Length 2, trailing comma forces tall.
+let a = [1, 2];
+let b = [1, 2];
+let c = [
+  1,
+  2,
+];
+let d = [
+  1,
+  2,
+];
+
+// Sets.
+let z = {1};
+let a = {1, 2};
+let b = {1, 2};
+let c = {
+  1,
+  2,
+};
+let d = {
+  1,
+  2,
+};
+
+// Dicts.
+let z = { a = 1 };
+let a = { a = 1, b = 2 };
+let b = { a = 1, b = 2 };
+let c = {
+  a = 1,
+  b = 2,
+};
+let d = {
+  a = 1,
+  b = 2,
+};
+
+// Function calls.
+let z = f(1);
+let a = f(1, 2);
+let b = f(1, 2);
+let c = f(
+  1,
+  2,
+);
+let d = f(
+  1,
+  2,
+);
+
+// Function definitions.
+let z = x => 1;
+let a = (x, y) => 1;
+let b = (x, y) => 1;
+let c = (
+  x,
+  y,
+) => 1;
+let d = (
+  x,
+  y,
+) => 1;
+
+null

--- a/golden/fmt/magic_trailing_comma.test
+++ b/golden/fmt/magic_trailing_comma.test
@@ -68,6 +68,28 @@ let d = (
   x, y,
 ) => 1;
 
+// Generic types.
+let z: List[Int,] = [];
+let a: List[Int, Int] = [];
+let b: List[
+  Int, Int
+] = [];
+let c: List[Int, Int,] = [];
+let d: List[
+  Int, Int,
+] = [];
+
+// Function types.
+let z: (Int,) -> Int = null;
+let a: (Int, Int) -> Int = null;
+let b: (
+  Int, Int
+) -> Int = null;
+let c: (Int, Int,) -> Int = null;
+let d: (
+  Int, Int,
+) -> Int = null;
+
 null
 
 # output:
@@ -146,5 +168,31 @@ let d = (
   x,
   y,
 ) => 1;
+
+// Generic types.
+let z: List[Int] = [];
+let a: List[Int, Int] = [];
+let b: List[Int, Int] = [];
+let c: List[
+  Int,
+  Int,
+] = [];
+let d: List[
+  Int,
+  Int,
+] = [];
+
+// Function types.
+let z: (Int) -> Int = null;
+let a: (Int, Int) -> Int = null;
+let b: (Int, Int) -> Int = null;
+let c: (
+  Int,
+  Int,
+) -> Int = null;
+let d: (
+  Int,
+  Int,
+) -> Int = null;
 
 null

--- a/golden/fmt/number_literals.test
+++ b/golden/fmt/number_literals.test
@@ -5,4 +5,8 @@
 ]
 
 # output:
-[0xffff_ffff, 0b0101_0101, 1e10]
+[
+  0xffff_ffff,
+  0b0101_0101,
+  1e10,
+]

--- a/src/abstraction.rs
+++ b/src/abstraction.rs
@@ -166,6 +166,7 @@ impl<'a> Abstractor<'a> {
             CExpr::BraceLit { open, elements, .. } => AExpr::BraceLit {
                 open: *open,
                 elements: elements
+                    .elements
                     .iter()
                     .map(|elem| self.seq(&elem.inner))
                     .collect::<Result<Vec<_>>>()?,
@@ -174,6 +175,7 @@ impl<'a> Abstractor<'a> {
             CExpr::BracketLit { open, elements, .. } => AExpr::BracketLit {
                 open: *open,
                 elements: elements
+                    .elements
                     .iter()
                     .map(|elem| self.seq(&elem.inner))
                     .collect::<Result<Vec<_>>>()?,
@@ -252,6 +254,7 @@ impl<'a> Abstractor<'a> {
                 ..
             } => AExpr::Function {
                 args: args
+                    .elements
                     .iter()
                     .map(|arg| (arg.inner, arg.inner.resolve(self.input).into()))
                     .collect(),
@@ -399,6 +402,7 @@ impl<'a> Abstractor<'a> {
                 function_span: inner_span,
                 function: Box::new(inner),
                 args: args
+                    .elements
                     .iter()
                     .map(|(span, a)| {
                         Ok(CallArg {

--- a/src/abstraction.rs
+++ b/src/abstraction.rs
@@ -442,6 +442,7 @@ impl<'a> Abstractor<'a> {
                 span: *span,
                 name: name.resolve(self.input).into(),
                 args: args
+                    .elements
                     .iter()
                     .map(|arg| self.type_expr(&arg.inner))
                     .collect::<Result<Box<_>>>()?,
@@ -449,6 +450,7 @@ impl<'a> Abstractor<'a> {
             CType::Function { span, args, result } => AType::Function {
                 span: *span,
                 args: args
+                    .elements
                     .iter()
                     .map(|arg| self.type_expr(&arg.inner))
                     .collect::<Result<Box<_>>>()?,

--- a/src/cst.rs
+++ b/src/cst.rs
@@ -100,6 +100,23 @@ pub struct Prefixed<T> {
 /// A prefixed expression, and the span of the inner expression.
 pub type SpanPrefixedExpr = (Span, Prefixed<Expr>);
 
+/// A collection of `T`s separated by commas, with an optional trailing comma and non-code suffix.
+///
+/// This is a list in the sense of a sequence of elements, it is not a list
+/// literal in the source code. `List<T>` only describes elements, not the
+/// surrounding delimiters like `[]`, `()`, or `{}`.
+#[derive(Debug)]
+pub struct List<T> {
+    /// The collection elements.
+    pub elements: Box<[T]>,
+
+    /// Any non-code before the closing delimiter.
+    pub suffix: Box<[NonCode]>,
+
+    /// Whether a trailing comma is present.
+    pub trailing_comma: bool,
+}
+
 /// A part of a string literal or format string.
 #[derive(Debug)]
 pub enum StringPart {
@@ -164,18 +181,14 @@ pub enum Expr {
     BraceLit {
         open: Span,
         close: Span,
-        elements: Box<[Prefixed<Seq>]>,
-        /// Any content before the closing brace.
-        suffix: Box<[NonCode]>,
+        elements: List<Prefixed<Seq>>,
     },
 
     /// A `[]`-enclosed collection literal.
     BracketLit {
         open: Span,
         close: Span,
-        elements: Box<[Prefixed<Seq>]>,
-        /// Any content before the closing bracket.
-        suffix: Box<[NonCode]>,
+        elements: List<Prefixed<Seq>>,
     },
 
     /// An expression enclosed in `()`.
@@ -230,9 +243,7 @@ pub enum Expr {
 
     /// Define a lambda function.
     Function {
-        args: Box<[Prefixed<Span>]>,
-        /// Any non-code between the final arg and the closing paren.
-        suffix: Box<[NonCode]>,
+        args: List<Prefixed<Span>>,
         body_span: Span,
         body: Box<Expr>,
     },
@@ -387,9 +398,7 @@ pub enum Chain {
         /// The closing parenthesis.
         close: Span,
         /// The arguments passed to the call.
-        args: Box<[SpanPrefixedExpr]>,
-        /// Any non-code between the final argument and the closing paren.
-        suffix: Box<[NonCode]>,
+        args: List<SpanPrefixedExpr>,
     },
 
     /// Index into a collection with `[]`.

--- a/src/cst.rs
+++ b/src/cst.rs
@@ -427,13 +427,13 @@ pub enum Type {
     Apply {
         span: Span,
         name: Span,
-        args: Box<[Prefixed<Type>]>,
+        args: List<Prefixed<Type>>,
     },
 
     /// A function type with zero or more arguments, and one result type.
     Function {
         span: Span,
-        args: Box<[Prefixed<Type>]>,
+        args: List<Prefixed<Type>>,
         result: Box<Type>,
     },
 }

--- a/src/fmt_cst.rs
+++ b/src/fmt_cst.rs
@@ -11,7 +11,7 @@
 //! pretty-printed for formatting.
 
 use crate::ast::UnOp;
-use crate::cst::{Chain, Expr, NonCode, Prefixed, Seq, Stmt, StringPart, Type};
+use crate::cst::{Chain, Expr, List, NonCode, Prefixed, Seq, Stmt, StringPart, Type};
 use crate::lexer::{QuoteStyle, StringPrefix};
 use crate::markup::Markup;
 use crate::pprint::{concat, flush_indent, group, indent, Doc};
@@ -285,34 +285,30 @@ impl<'a> Formatter<'a> {
                 }
             }
 
-            Expr::BraceLit {
-                elements, suffix, ..
-            } => {
-                if elements.is_empty() && suffix.is_empty() {
+            Expr::BraceLit { elements, .. } => {
+                if elements.elements.is_empty() && elements.suffix.is_empty() {
                     Doc::str("{}")
                 } else {
                     let sep = self
-                        .sep_key_value(elements)
-                        .or(self.soft_break_if_not_empty(elements));
+                        .sep_key_value(&elements.elements)
+                        .or(self.soft_break_if_not_empty(&elements.elements));
                     group! {
                         "{"
                         sep
-                        indent! { self.seqs(elements, suffix) }
+                        indent! { self.seqs(elements) }
                         "}"
                     }
                 }
             }
 
-            Expr::BracketLit {
-                elements, suffix, ..
-            } => {
-                if elements.is_empty() && suffix.is_empty() {
+            Expr::BracketLit { elements, .. } => {
+                if elements.elements.is_empty() && elements.suffix.is_empty() {
                     Doc::str("[]")
                 } else {
                     group! {
                         "["
-                        self.soft_break_if_not_empty(elements)
-                        indent! { self.seqs(elements, suffix) }
+                        self.soft_break_if_not_empty(&elements.elements)
+                        indent! { self.seqs(elements) }
                         "]"
                     }
                 }
@@ -388,22 +384,22 @@ impl<'a> Formatter<'a> {
                 }
             }
 
-            Expr::Function {
-                args, suffix, body, ..
-            } => {
-                let args_doc: Doc = match args.len() {
+            Expr::Function { args, body, .. } => {
+                let args_doc: Doc = match args.elements.len() {
                     0 => Doc::str("()"),
                     // Don't put parens around the argument if there is a single
                     // argument that has no comments on it. If it has comments,
                     // then we need the parens, because otherwise we might
                     // produce a syntax error in the output.
-                    1 if args[0].prefix.is_empty() && suffix.is_empty() => self.span(args[0].inner),
+                    1 if args.elements[0].prefix.is_empty() && args.suffix.is_empty() => {
+                        self.span(args.elements[0].inner)
+                    }
                     _ => group! {
                         "("
                         Doc::SoftBreak
                         indent! {
                             Doc::join(
-                                args.iter().map(|arg| concat! {
+                                args.elements.iter().map(|arg| concat! {
                                     self.non_code(&arg.prefix)
                                     self.span(arg.inner)
                                 }),
@@ -411,7 +407,7 @@ impl<'a> Formatter<'a> {
                             )
                             Doc::tall(",")
                             Doc::SoftBreak
-                            self.non_code(suffix)
+                            self.non_code(&args.suffix)
                         }
                         ")"
                     },
@@ -474,18 +470,18 @@ impl<'a> Formatter<'a> {
                     group.push(".".into());
                     group.push(self.span(*field));
                 }
-                Chain::Call { args, suffix, .. } => {
+                Chain::Call { args, .. } => {
                     let call_doc = group! {
                         "("
                         Doc::SoftBreak
                         indent! {
                             Doc::join(
-                                args.iter().map(|(_span, arg)| self.prefixed_expr(arg)),
+                                args.elements.iter().map(|(_span, arg)| self.prefixed_expr(arg)),
                                 concat!{ "," Doc::Sep },
                             )
                             Doc::tall(",")
                             Doc::SoftBreak
-                            self.non_code(suffix)
+                            self.non_code(&args.suffix)
                         }
                         ")"
                     };
@@ -520,9 +516,9 @@ impl<'a> Formatter<'a> {
         }
     }
 
-    pub fn seqs(&self, elements: &[Prefixed<Seq>], suffix: &[NonCode]) -> Doc<'a> {
+    pub fn seqs(&self, seqs: &List<Prefixed<Seq>>) -> Doc<'a> {
         let mut result = Vec::new();
-        for (i, elem) in elements.iter().enumerate() {
+        for (i, elem) in seqs.elements.iter().enumerate() {
             let elem_doc = self.seq(&elem.inner);
 
             // We wrap the inner Seq in a group, so you can have a collection
@@ -532,7 +528,7 @@ impl<'a> Formatter<'a> {
             result.push(self.non_code(&elem.prefix));
             result.push(group! { elem_doc });
 
-            let is_last = i + 1 == elements.len();
+            let is_last = i + 1 == seqs.elements.len();
             let sep_doc = match i {
                 // For collections that contain a single comprehension, do not
                 // add a separator, even when they are multi-line. It makes
@@ -540,8 +536,8 @@ impl<'a> Formatter<'a> {
                 // but only rarely are there multiple seqs in the collection.
                 // If there is suffix noncode, then we need the separator before
                 // it, otherwise we would output a syntax error.
-                _ if elements.len() == 1 && suffix.is_empty() => {
-                    if elements[0].inner.is_comprehension() {
+                _ if seqs.elements.len() == 1 && seqs.suffix.is_empty() => {
+                    if seqs.elements[0].inner.is_comprehension() {
                         Doc::Empty
                     } else {
                         Doc::tall(",")
@@ -558,12 +554,12 @@ impl<'a> Formatter<'a> {
         }
 
         // Depending on whether we have key-values, add a soft break or sep.
-        result.push(self.sep_key_value(elements).unwrap_or(Doc::SoftBreak));
+        result.push(self.sep_key_value(&seqs.elements).unwrap_or(Doc::SoftBreak));
 
         // We could do it non-conditionally and push an empty doc, but seq is
         // a very common thing and suffixes are not, so efficiency matters here.
-        if !suffix.is_empty() {
-            result.push(self.non_code(suffix));
+        if !seqs.suffix.is_empty() {
+            result.push(self.non_code(&seqs.suffix));
         }
 
         Doc::Concat(result)


### PR DESCRIPTION
Inspired by [Black’s magic trailing comma](https://black.readthedocs.io/en/stable/the_black_code_style/current_style.html#the-magic-trailing-comma), this is actually very useful for real-world cases. For example, the GitHub Actions example benefits from this.

Adding this forced creating a reusable data structure for lists of things, which also resolves one to-do where the type expression parser would drop comments.