### PR TITLE
Improve formatting of statement chains

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -20,8 +20,12 @@ Unreleased.
 
 **Changes with compatibility impact:**
 
-* The output of the formatter can differ significantly. This may cause large
-  diffs in codebases where formatting is enforced. See below for more details.
+ * The output of the formatter can differ significantly. This may cause large
+   diffs in codebases where formatting is enforced. See below for more details.
+ * Certain syntactic constructs are no longer allowed inside the condition after
+   `if`. If this causes a problem, simply wrap the condition in parentheses. The
+   stricter syntax ensures that conditionals can always be formatted in a
+   reasonable way without loss in expressiveness.
 
 All changes:
 

--- a/golden/error/parse_term_needs_paren.test
+++ b/golden/error/parse_term_needs_paren.test
@@ -1,0 +1,12 @@
+let valid = [for x in (let ys = [1, 2, 3]; ys): x];
+let invalid = [for x in let ys = [1, 2, 3]; ys: x];
+invalid
+
+# output:
+stdin:2:25
+  ╷
+2 │ let invalid = [for x in let ys = [1, 2, 3]; ys: x];
+  ╵                         ^~~
+Error: Expected a term here.
+
+Help: If this should be an expression, try wrapping it in parentheses.

--- a/golden/fmt/fstring.test
+++ b/golden/fmt/fstring.test
@@ -22,6 +22,17 @@ let z1 = f"""
   {"^ Tab above."}
   """;
 
+// Here we have a comment inside the hole, which makes it multi-line.
+let hole1 = f"Beware: {
+// A comment
+0
+}";
+let hole1 = f"""
+This one has a blank line instead: {
+
+0
+}""";
+
 f"""
 This { let strtype = "f"; strtype }-string has a hole too.
 """
@@ -29,10 +40,12 @@ This { let strtype = "f"; strtype }-string has a hole too.
 # output:
 let x = f"This f-string has {"a hole"} inside it.";
 
-let y = f"This f-string has {[
-  // A list with a comment.
-  "in a hole",
-]} inside it.";
+let y = f"This f-string has {
+  [
+    // A list with a comment.
+    "in a hole",
+  ]
+} inside it.";
 
 // The next one is a regression test; a bug would drop the content after the
 // hole.
@@ -47,6 +60,18 @@ let z1 =
   \t this one.
   {"^ Tab above."}
   """;
+
+// Here we have a comment inside the hole, which makes it multi-line.
+let hole1 = f"Beware: {
+  // A comment
+  0
+}";
+let hole1 =
+  f"""
+  This one has a blank line instead: {
+
+    0
+  }""";
 
 f"""
 This {let strtype = "f"; strtype}-string has a hole too.

--- a/golden/fmt/list_comprehension.test
+++ b/golden/fmt/list_comprehension.test
@@ -22,11 +22,10 @@ let double_comprehension = [
     .is_marzlevane():
   h.frobnicated(),
 ];
-// TODO: All-or-nothing let chain wide or tall.
 let b = [
   1,
-];
-a + b
+]; a +
+b
 
 # output:
 // With a single element, there is never a separator, even when it is tall.
@@ -53,5 +52,5 @@ let double_comprehension = [
   for m in extract_marzlevanes().is_hydrocoptic(): m.frobnicated(),
   for h in extract_hydrocoptics().is_marzlevane(): h.frobnicated(),
 ];
-// TODO: All-or-nothing let chain wide or tall.
-let b = [1]; a + b
+let b = [1];
+a + b

--- a/golden/fmt/statement_complexity.test
+++ b/golden/fmt/statement_complexity.test
@@ -1,0 +1,19 @@
+// This is still okay, one statement.
+let okay = let x = 1; 1 + x;
+
+// This, despite fitting on one line, wraps because it has two statements.
+let wrap = let x = 1; let y = 2; 1 + x + y;
+
+okay + wrap
+
+# output:
+// This is still okay, one statement.
+let okay = let x = 1; 1 + x;
+
+// This, despite fitting on one line, wraps because it has two statements.
+let wrap =
+  let x = 1;
+  let y = 2;
+  1 + x + y;
+
+okay + wrap

--- a/golden/fmt/types_blank_in_annotation.test
+++ b/golden/fmt/types_blank_in_annotation.test
@@ -10,4 +10,5 @@ T = q;
 // This is a regression test for a non-idempotency discovered by the fuzzer.
 // The blank line should be removed entirely, but previously it turned into a
 // single newline, which then got removed on a second fmt iteration.
-let x: T = q; 0
+let x: T = q;
+0

--- a/golden/types/static_collection_dict_not_kv.test
+++ b/golden/types/static_collection_dict_not_kv.test
@@ -5,7 +5,7 @@ xs
 stdin:1:28
   ╷
 1 │ let xs: Dict[Int, Int] = { "scalar" };
-  ╵                            ^~~~~~~~~
+  ╵                            ^~~~~~~~
 Error: Expected key-value, not a scalar element, because the collection is a dict.
 
 stdin:1:9

--- a/grammar/bison/grammar.y
+++ b/grammar/bison/grammar.y
@@ -123,7 +123,7 @@ seq
   | expr_op ':' expr
   | IDENT '=' expr ',' seq
   | stmt seq
-  | "for" idents "in" expr ':' seq
+  | "for" idents "in" expr_op ':' seq
   | "if" expr_op ':' seq
   ;
 

--- a/grammar/bison/grammar.y
+++ b/grammar/bison/grammar.y
@@ -24,7 +24,7 @@ expr
   ;
 
 expr_stmt: stmt expr;
-expr_if: "if" expr ':' expr "else" expr;
+expr_if: "if" expr_op ':' expr "else" expr;
 expr_import: "import" expr;
 
 // There is no operator precedence, so if there is an operator, its args must
@@ -124,7 +124,7 @@ seq
   | IDENT '=' expr ',' seq
   | stmt seq
   | "for" idents "in" expr ':' seq
-  | "if" expr ':' seq
+  | "if" expr_op ':' seq
   ;
 
 idents: IDENT | idents ',' IDENT;

--- a/grammar/tree-sitter-rcl/grammar.js
+++ b/grammar/tree-sitter-rcl/grammar.js
@@ -262,7 +262,7 @@ module.exports = grammar({
       "for",
       field("idents", $._idents),
       "in",
-      field("collection", $._expr),
+      field("collection", $._expr_op),
       ":",
       field("body", $._seq),
     ),

--- a/grammar/tree-sitter-rcl/grammar.js
+++ b/grammar/tree-sitter-rcl/grammar.js
@@ -135,7 +135,7 @@ module.exports = grammar({
 
     expr_if: $ => seq(
       "if",
-      field("condition", $._expr),
+      field("condition", $._expr_op),
       ":",
       field("then", $._expr),
       "else",
@@ -268,7 +268,7 @@ module.exports = grammar({
     ),
     seq_if: $ => seq(
       "if",
-      field("condition", $._expr),
+      field("condition", $._expr_op),
       ":",
       field("body", $._seq),
     ),

--- a/src/abstraction.rs
+++ b/src/abstraction.rs
@@ -16,7 +16,6 @@
 use crate::ast::{
     CallArg, Expr as AExpr, Expr, FormatFragment, Seq as ASeq, Stmt as AStmt, Type as AType, Yield,
 };
-use crate::cst::Prefixed;
 use crate::cst::{Chain, Expr as CExpr, Seq as CSeq, Stmt as CStmt, StringPart, Type as CType};
 use crate::error::{IntoError, Result};
 use crate::lexer::QuoteStyle;
@@ -24,8 +23,8 @@ use crate::source::Span;
 use crate::string;
 
 /// Abstract an expression.
-pub fn abstract_expr(input: &str, expr: &Prefixed<CExpr>) -> Result<AExpr> {
-    Abstractor::new(input).expr(&expr.inner)
+pub fn abstract_expr(input: &str, expr: &CExpr) -> Result<AExpr> {
+    Abstractor::new(input).expr(expr)
 }
 
 /// The abstractor can convert CST nodes to AST nodes for a given document.
@@ -171,7 +170,7 @@ impl<'a> Abstractor<'a> {
 
             CExpr::Import { path_span, path } => AExpr::Import {
                 path_span: *path_span,
-                path: Box::new(self.expr(&path.inner)?),
+                path: Box::new(self.expr(path)?),
             },
 
             CExpr::BraceLit { open, elements, .. } => AExpr::BraceLit {
@@ -192,7 +191,7 @@ impl<'a> Abstractor<'a> {
                     .collect::<Result<Vec<_>>>()?,
             },
 
-            CExpr::Parens { body, .. } => self.expr(&body.inner)?,
+            CExpr::Parens { body, .. } => self.expr(body)?,
 
             CExpr::NullLit(_span) => AExpr::NullLit,
 
@@ -249,8 +248,8 @@ impl<'a> Abstractor<'a> {
                 span_then: *then_span,
                 span_else: *else_span,
                 condition: Box::new(self.expr(condition)?),
-                body_then: Box::new(self.expr(&then_body.inner)?),
-                body_else: Box::new(self.expr(&else_body.inner)?),
+                body_then: Box::new(self.expr(then_body)?),
+                body_else: Box::new(self.expr(else_body)?),
             },
 
             CExpr::Var(span) => AExpr::Var {
@@ -435,7 +434,7 @@ impl<'a> Abstractor<'a> {
                 collection_span: inner_span,
                 collection: Box::new(inner),
                 index_span: *index_span,
-                index: Box::new(self.expr(&index.inner)?),
+                index: Box::new(self.expr(index)?),
             },
         };
 

--- a/src/abstraction.rs
+++ b/src/abstraction.rs
@@ -417,7 +417,7 @@ impl<'a> Abstractor<'a> {
                     .map(|(span, a)| {
                         Ok(CallArg {
                             span: *span,
-                            value: self.expr(&a.inner)?,
+                            value: self.expr(a)?,
                         })
                     })
                     .collect::<Result<Vec<_>>>()?,

--- a/src/cst.rs
+++ b/src/cst.rs
@@ -100,6 +100,9 @@ pub struct Prefixed<T> {
 /// A prefixed expression, and the span of the inner expression.
 pub type SpanPrefixedExpr = (Span, Prefixed<Expr>);
 
+/// A prefixed statement, and the span of the inner statement.
+pub type SpanPrefixedStmt = (Span, Prefixed<Stmt>);
+
 /// A collection of `T`s separated by commas, with an optional trailing comma and non-code suffix.
 ///
 /// This is a list in the sense of a sequence of elements, it is not a list
@@ -161,9 +164,9 @@ pub enum Stmt {
 
 #[derive(Debug)]
 pub enum Expr {
-    /// A statement-like expression.
-    Stmt {
-        stmt: Stmt,
+    /// An expression preceded by a prefix and/or one or more statements.
+    Statements {
+        stmts: Vec<SpanPrefixedStmt>,
         body_span: Span,
         body: Box<Prefixed<Expr>>,
     },

--- a/src/cst.rs
+++ b/src/cst.rs
@@ -97,9 +97,6 @@ pub struct Prefixed<T> {
     pub inner: T,
 }
 
-/// A prefixed expression, and the span of the inner expression.
-pub type SpanPrefixedExpr = (Span, Prefixed<Expr>);
-
 /// A prefixed statement, and the span of the inner statement.
 pub type SpanPrefixedStmt = (Span, Prefixed<Stmt>);
 
@@ -401,7 +398,7 @@ pub enum Chain {
         /// The closing parenthesis.
         close: Span,
         /// The arguments passed to the call.
-        args: List<SpanPrefixedExpr>,
+        args: List<(Span, Expr)>,
     },
 
     /// Index into a collection with `[]`.

--- a/src/cst.rs
+++ b/src/cst.rs
@@ -177,7 +177,7 @@ pub enum Expr {
         path_span: Span,
 
         /// An expression that evaluates to the path to import.
-        path: Box<Prefixed<Expr>>,
+        path: Box<Expr>,
     },
 
     /// A `{}`-enclosed collection literal.
@@ -199,7 +199,7 @@ pub enum Expr {
         open: Span,
         close: Span,
         body_span: Span,
-        body: Box<Prefixed<Expr>>,
+        body: Box<Expr>,
     },
 
     /// A null literal.
@@ -239,9 +239,9 @@ pub enum Expr {
         condition_span: Span,
         condition: Box<Expr>,
         then_span: Span,
-        then_body: Box<Prefixed<Expr>>,
+        then_body: Box<Expr>,
         else_span: Span,
-        else_body: Box<Prefixed<Expr>>,
+        else_body: Box<Expr>,
     },
 
     /// Define a lambda function.
@@ -413,7 +413,7 @@ pub enum Chain {
         /// The span of the index expression between the `[]`.
         index_span: Span,
         /// The index expression.
-        index: Box<Prefixed<Expr>>,
+        index: Box<Expr>,
     },
 }
 

--- a/src/fmt_cst.rs
+++ b/src/fmt_cst.rs
@@ -19,12 +19,13 @@ use crate::source::Span;
 use crate::string;
 
 /// Format a document.
-pub fn format_expr<'a>(input: &'a str, expr: &'a Prefixed<Expr>) -> Doc<'a> {
+pub fn format_expr<'a>(input: &'a str, expr: &'a Expr) -> Doc<'a> {
     let formatter = Formatter::new(input);
     // Usually the entire thing is already wrapped in a group, but we need to
     // add one in case it is not, to enable wide formatting of expressions that
     // are not a group at the top level.
-    Doc::Group(Box::new(formatter.prefixed_expr(expr)))
+    // TODO: Is that still true without the prefix though?
+    Doc::Group(Box::new(formatter.expr(expr)))
 }
 
 /// Helper so we can use methods for resolving spans against the input.
@@ -306,8 +307,7 @@ impl<'a> Formatter<'a> {
                         Doc::str("import").with_markup(Markup::Keyword)
                         indent! {
                             Doc::Sep
-                            self.non_code(&path.prefix)
-                            self.expr(&path.inner)
+                            self.expr(path)
                         }
                     }
                 }
@@ -347,7 +347,7 @@ impl<'a> Formatter<'a> {
                 group! {
                     "("
                     Doc::SoftBreak
-                    indent! { self.prefixed_expr(body) }
+                    indent! { self.expr(body) }
                     Doc::SoftBreak
                     ")"
                 }
@@ -404,11 +404,11 @@ impl<'a> Formatter<'a> {
                         " "
                         self.expr(condition) ":"
                         Doc::Sep
-                        indent! { self.prefixed_expr(then_body) }
+                        indent! { self.expr(then_body) }
                         Doc::Sep
                         Doc::str("else").with_markup(Markup::Keyword)
                         Doc::Sep
-                        indent! { self.prefixed_expr(else_body) }
+                        indent! { self.expr(else_body) }
                     }
                 }
             }
@@ -517,7 +517,7 @@ impl<'a> Formatter<'a> {
                     let index_doc = group! {
                         "["
                         Doc::SoftBreak
-                        indent! { self.prefixed_expr(index) }
+                        indent! { self.expr(index) }
                         Doc::SoftBreak
                         "]"
                     };

--- a/src/fmt_cst.rs
+++ b/src/fmt_cst.rs
@@ -142,9 +142,16 @@ impl<'a> Formatter<'a> {
                     result.push(self.span(*span).with_markup(Markup::Escape));
                 }
                 StringPart::Hole(_span, expr) => {
-                    // TODO: Add soft breaks around the hole contents?
                     result.push(Doc::str("{").with_markup(Markup::Escape));
-                    result.push(self.expr(expr));
+                    // We need soft breaks here in case the expression contains
+                    // forced breaks, for example when it has non-code.
+                    result.push(group! {
+                        indent! {
+                            Doc::SoftBreak
+                            self.expr(expr)
+                            Doc::SoftBreak
+                        }
+                    });
                     result.push(Doc::str("}").with_markup(Markup::Escape));
                 }
             }
@@ -211,9 +218,16 @@ impl<'a> Formatter<'a> {
                     result.push(self.span(*span).with_markup(Markup::Escape));
                 }
                 StringPart::Hole(_span, expr) => {
-                    // TODO: Add soft breaks around the hole contents?
                     result.push(Doc::str("{").with_markup(Markup::Escape));
-                    result.push(self.expr(expr));
+                    // We need soft breaks here in case the expression contains
+                    // forced breaks, for example when it has non-code.
+                    result.push(group! {
+                        indent! {
+                            Doc::SoftBreak
+                            self.expr(expr)
+                            Doc::SoftBreak
+                        }
+                    });
                     result.push(Doc::str("}").with_markup(Markup::Escape));
                 }
             }

--- a/src/fmt_cst.rs
+++ b/src/fmt_cst.rs
@@ -224,13 +224,6 @@ impl<'a> Formatter<'a> {
         flush_indent! { Doc::Concat(result) }
     }
 
-    pub fn prefixed_expr(&self, expr: &Prefixed<Expr>) -> Doc<'a> {
-        concat! {
-            self.non_code(&expr.prefix)
-            self.expr(&expr.inner)
-        }
-    }
-
     pub fn prefixed_type(&self, type_: &Prefixed<Type>) -> Doc<'a> {
         concat! {
             self.non_code(&type_.prefix)
@@ -503,7 +496,7 @@ impl<'a> Formatter<'a> {
                         self.collection_opening_sep(args)
                         indent! {
                             Doc::join(
-                                args.elements.iter().map(|(_span, arg)| self.prefixed_expr(arg)),
+                                args.elements.iter().map(|(_span, arg)| self.expr(arg)),
                                 concat!{ "," Doc::Sep },
                             )
                             self.trailing_comma(args)

--- a/src/fmt_cst.rs
+++ b/src/fmt_cst.rs
@@ -292,11 +292,19 @@ impl<'a> Formatter<'a> {
         match expr {
             Expr::Statements { stmts, body, .. } => {
                 let mut parts = Vec::new();
+                // If we have two or more statements, then always format tall,
+                // even if it would fit on a line. If you have that many
+                // statements it's probably complex, a oneliner might make it
+                // hard to understand.
+                let sep = if stmts.len() >= 2 {
+                    Doc::HardBreak
+                } else {
+                    Doc::Sep
+                };
                 for (_span, stmt) in stmts.iter() {
                     parts.push(self.non_code(&stmt.prefix));
                     parts.push(self.stmt(&stmt.inner));
-                    // TODO: Force a hard break if it's more than 2, like with Seq depth?
-                    parts.push(Doc::Sep);
+                    parts.push(sep.clone());
                 }
                 parts.push(self.non_code(&body.prefix));
                 parts.push(self.expr(&body.inner));

--- a/src/fmt_cst.rs
+++ b/src/fmt_cst.rs
@@ -20,12 +20,7 @@ use crate::string;
 
 /// Format a document.
 pub fn format_expr<'a>(input: &'a str, expr: &'a Expr) -> Doc<'a> {
-    let formatter = Formatter::new(input);
-    // Usually the entire thing is already wrapped in a group, but we need to
-    // add one in case it is not, to enable wide formatting of expressions that
-    // are not a group at the top level.
-    // TODO: Is that still true without the prefix though?
-    Doc::Group(Box::new(formatter.expr(expr)))
+    Formatter::new(input).expr(expr)
 }
 
 /// Helper so we can use methods for resolving spans against the input.

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -395,7 +395,7 @@ impl Loader {
     }
 
     /// Parse the given document and return its Concrete Syntax Tree.
-    pub fn get_cst(&self, id: DocId) -> Result<cst::Prefixed<cst::Expr>> {
+    pub fn get_cst(&self, id: DocId) -> Result<cst::Expr> {
         let doc = self.get_doc(id);
         let tokens = self.get_tokens(id)?;
         let (_doc_span, expr) = parser::parse(id, doc.data, &tokens)?;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1250,7 +1250,7 @@ impl<'a> Parser<'a> {
         self.parse_token(Token::KwIn, "Expected 'in' here.")?;
 
         self.skip_non_code()?;
-        let (collection_span, collection) = self.parse_expr()?;
+        let (collection_span, collection) = self.parse_expr_op()?;
 
         self.skip_non_code()?;
         self.parse_token(Token::Colon, "Expected ':' after the collection.")?;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -369,14 +369,22 @@ impl<'a> Parser<'a> {
     fn parse_expr_no_stmt(&mut self) -> Result<Expr> {
         match self.peek() {
             Some(Token::KwIf) => self.parse_expr_if(),
-            _ => self.parse_expr_op(),
+            _ => Ok(self.parse_expr_op()?.1),
         }
     }
 
     fn parse_expr_if(&mut self) -> Result<Expr> {
         // Consume the `if` keyword.
         let if_span = self.consume();
-        let (condition_span, condition) = self.parse_expr()?;
+
+        // We do not allow non-code between the if and the condition, and for
+        // the condition, we do not allow if or statements. There is no technical
+        // need to limit this, we could use `parse_expr`, but the resulting CST
+        // is a royal pain to format in a pleasant way. What to do with blank
+        // lines, how do you indent? And `if if` looks confusing anyway. If you
+        // want an expr there you can still do it, just put parens around it.
+        self.skip_non_code()?;
+        let (condition_span, condition) = self.parse_expr_op()?;
 
         self.skip_non_code()?;
         self.parse_token(Token::Colon, "Expected ':' after the condition.")?;
@@ -414,15 +422,15 @@ impl<'a> Parser<'a> {
         Ok(result)
     }
 
-    fn parse_expr_import(&mut self) -> Result<Expr> {
+    fn parse_expr_import(&mut self) -> Result<(Span, Expr)> {
         // Consume the `import` keyword.
-        let _import_span = self.consume();
+        let import_span = self.consume();
         let (path_span, path) = self.parse_expr()?;
         let result = Expr::Import {
             path_span,
             path: Box::new(path),
         };
-        Ok(result)
+        Ok((import_span.union(path_span), result))
     }
 
     /// Parse the statement under the cursor.
@@ -638,7 +646,8 @@ impl<'a> Parser<'a> {
     }
 
     /// Try parsing a lambda function expression.
-    fn parse_expr_function(&mut self) -> Result<Expr> {
+    fn parse_expr_function(&mut self) -> Result<(Span, Expr)> {
+        let begin = self.peek_span();
         let args = match self.peek() {
             Some(Token::Ident) => {
                 let prefixed = Prefixed {
@@ -670,16 +679,15 @@ impl<'a> Parser<'a> {
             body_span,
             body: Box::new(body),
         };
-        Ok(result)
+        Ok((self.span_from(begin), result))
     }
 
-    fn parse_expr_op(&mut self) -> Result<Expr> {
+    fn parse_expr_op(&mut self) -> Result<(Span, Expr)> {
         // First we check all the rules for prefix unary operators.
         self.check_bad_unop()?;
 
         if self.peek().and_then(to_unop).is_some() {
-            let (_span, result) = self.parse_expr_unop()?;
-            return Ok(result);
+            return self.parse_expr_unop();
         }
 
         // Instead of an operator chain, it could still be an import or lambda,
@@ -726,7 +734,7 @@ impl<'a> Parser<'a> {
                         "Without parentheses, it is not clear whether this operator should take precedence.",
                     ).err();
                 }
-                _ => return Ok(result),
+                _ => return Ok((lhs_span, result)),
             }
         }
     }
@@ -1173,11 +1181,7 @@ impl<'a> Parser<'a> {
             (Some(Token::KwFor), _) => self.parse_seq_for()?,
             (Some(Token::KwIf), _) => self.parse_seq_if()?,
             _ => {
-                let before = self.peek_span();
-                let expr = self.parse_expr_op()?;
-                // TODO: This span is not necessarily minimal, it may include
-                // whitespace.
-                let expr_span = before.until(self.peek_span());
+                let (expr_span, expr) = self.parse_expr_op()?;
                 self.skip_non_code()?;
                 match self.peek() {
                     Some(Token::Colon) => {
@@ -1266,8 +1270,10 @@ impl<'a> Parser<'a> {
     fn parse_seq_if(&mut self) -> Result<Seq> {
         let _if = self.consume();
 
+        // See also the note in `parse_expr_if` about why we don't allow
+        // arbitrary expressions here.
         self.skip_non_code()?;
-        let (condition_span, condition) = self.parse_expr()?;
+        let (condition_span, condition) = self.parse_expr_op()?;
 
         self.skip_non_code()?;
         self.parse_token(Token::Colon, "Expected ':' after the condition.")?;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -885,6 +885,14 @@ impl<'a> Parser<'a> {
             Some(Token::NumBinary) => Ok(Expr::NumBinary(self.consume())),
             Some(Token::NumDecimal) => Ok(Expr::NumDecimal(self.consume())),
             Some(Token::Ident) => Ok(Expr::Var(self.consume())),
+
+            // Some tokens are valid starts of an expression, but just not at
+            // the term level. For those, we can recommend the user to wrap
+            // everything in parens, because then it would be allowed.
+            Some(Token::KwLet | Token::KwAssert | Token::KwTrace | Token::KwIf) => self
+                .error("Expected a term here.")
+                .with_help("If this should be an expression, try wrapping it in parentheses.")
+                .err(),
             _ => self.error("Expected a term here.").err(),
         }
     }

--- a/src/string.rs
+++ b/src/string.rs
@@ -191,7 +191,7 @@ mod test {
         let doc = DocId(0);
         let tokens = crate::lexer::lex(doc, input).unwrap();
         let (_span, expr) = crate::parser::parse(doc, input, &tokens).unwrap();
-        match expr.inner {
+        match expr {
             StringLit { parts, .. } => parts,
             _ => panic!("Should have parsed a string."),
         }


### PR DESCRIPTION
## Background

A longstanding issue is that (like chained expressions before #53), a chain of statements gets formatted as a series of nested groups, which enable breaking anywhere, so you can get something like

```
let x = 1;
let y = 2; let z = 3; final_expr
```

To fix this, apply the same technique as in #53: change the CST so that chains of statements are no longer a degenerate tree of nodes that each have one statement and a body expression, but make one `Expr::Statements` node that can have multiple statements and one body. Then we can format the entire chain of statements as either wide or tall.

## Implementation

Changing this structure enabled me to get rid of `Prefixed<T>` in many places. The code in many places became simpler, while at the same time making the formatting work better. It felt like I discovered the right way to implement this.

But then I got to the comma delimited sequences again, that may have a suffix, and they break the pattern. I can let `parse_expr` take the prefix (like it does after this change), but then the sequence parsing methods that start by reading non-code prefix, and treat it as suffix when they encounter a closing delimiter, those become harder to do.

Also, having non-code in more places exposed some weaknesses in the formatter. One of them I fixed in the grammar, another in the parser. The gist of it is: when outputting an expression (that may have a non-code prefix), it needs to be preceded by a separator. Without that, if the prefix is a `Blank`, we only add one newline and the formatter becomes non-idempotent, or when the prefix is a comma, it goes directly after the previous content instead of going on its own line. So going through this exercise exposed that, and forced me to fix it.

As a drive-by fix, this resolves a to do about how spans are tracked (which shows as an improvement in the golden tests), and comments are now allowed in more places.

## Testing

 * [x] Run smith, source, and tree-sitter fuzzers for some an ~hour. During development the fuzzer uncovered a non-idempotency in the formatter. It has been addressed as explained above.
 * [x] Ensure test coverage.