### PR TITLE
Hint at using record syntax

### DIFF
--- a/golden/error/typecheck_unknown_variable_record_hint.test
+++ b/golden/error/typecheck_unknown_variable_record_hint.test
@@ -1,0 +1,16 @@
+{
+  user-wants-literal-text: "but used json syntax"
+}
+
+# output:
+stdin:2:3
+  ╷
+2 │   user-wants-literal-text: "but used json syntax"
+  ╵   ^~~~~~~~~~~~~~~~~~~~~~~
+Error: Unknown variable.
+
+stdin:2:26
+  ╷
+2 │   user-wants-literal-text: "but used json syntax"
+  ╵                          ^
+Note: To use unquoted keys, replace ':' with '='.

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -857,11 +857,11 @@ impl<'a> TypeChecker<'a> {
                     let k = match self.check_expr(type_any(), *key_span, key) {
                         Err(err) if matches!(key.as_ref(), Expr::Var { .. }) => {
                             err.with_note(*op_span, concat! {
-                                "For unquoted string literals use the record syntax. (replace '" 
+                                "To use unquoted keys, replace '" 
                                 Doc::highlight(":")
                                 "' with '"
                                 Doc::highlight("=")
-                                "')"
+                                "'."
                             }).err()
                         }
                         other => other,


### PR DESCRIPTION
Little something I ran into a couple of times and left me slightly confused.

In the expression `{ key: true }` (json syntax) `key` is interpreted as an identifier whereas in `{ key = true }` (record syntax) `key` is a string literal.

This hint should highlight that possible syntax mixup.