### PR TITLE
Add `std.empty_set` constant

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -17,6 +17,7 @@ compatibility impact will be clearly marked as such in the changelog.
 ## Unreleased
 
  * Add [`List.sort`](type_list.md#sort) method.
+ * Add [`std.empty_set`](stdlib.md#empty_set) constant.
 
 ## 0.6.0
 

--- a/docs/stdlib.md
+++ b/docs/stdlib.md
@@ -1,8 +1,18 @@
 # Standard library
 
-The <abbr>RCL</abbr> standard library is a dict of functions that is in scope by
+The <abbr>RCL</abbr> standard library is a dict of values that is in scope by
 default under the name `std`. Most of the built-in functionality is not in this
 `std` dict, but in methods on the builtin types. See the next chapters for those.
+
+## empty_set
+
+```rcl
+std.empty_set: Set[Void]
+```
+
+An empty set. This constant exists, because without type annotations, `{}` is an
+empty dict rather than an empty set. This constant is the standard way to refer
+to an empty set.
 
 ## range
 

--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -134,13 +134,8 @@ list contains two identical sets:
 ```
 
 Note, without type annotations, the empty collection `{}` is a dict, not a set.
-To produce an empty set, we can use a set comprehension:
-
-```rcl
-{for x in []: x}
-```
-
-Or we can use a type annotation to force `{}` to be a set:
+To produce an empty set, we can use [`std.empty_set`](stdlib.md#empty_set). A
+type annotation will also force `{}` to be a set:
 
 ```rcl
 let empty_set: Set[Int] = {};

--- a/fuzz/dictionary.txt
+++ b/fuzz/dictionary.txt
@@ -47,6 +47,7 @@
 # Builtin methods.
 "chars"
 "contains"
+"empty_set"
 "ends_with"
 "enumerate"
 "except"

--- a/golden/error/type_index_dict_fn_key.test
+++ b/golden/error/type_index_dict_fn_key.test
@@ -13,7 +13,11 @@ Error: Type mismatch. Expected a value that fits this type:
 
 But got this value:
 
-  { range = std.range, read_file_utf8 = std.read_file_utf8 }
+  {
+    empty_set = std.empty_set,
+    range = std.range,
+    read_file_utf8 = std.read_file_utf8,
+  }
 
 stdin:1:9
   ╷

--- a/golden/rcl/set_empty_annotation.test
+++ b/golden/rcl/set_empty_annotation.test
@@ -3,4 +3,4 @@ let empty: Set[Int] = {};
 empty
 
 # output:
-{}
+std.empty_set

--- a/golden/rcl/set_empty_std.test
+++ b/golden/rcl/set_empty_std.test
@@ -1,4 +1,4 @@
-{ for x in []: x }
+std.empty_set
 
 # output:
 std.empty_set

--- a/grammar/pygments/rcl.py
+++ b/grammar/pygments/rcl.py
@@ -62,6 +62,7 @@ _root_base = [
             (
                 "chars",
                 "contains",
+                "empty_set",
                 "ends_with",
                 "enumerate",
                 "except",

--- a/grammar/rcl.vim/syntax/rcl.vim
+++ b/grammar/rcl.vim/syntax/rcl.vim
@@ -45,7 +45,7 @@ syn region  rclFormatTriple  start='f"""' end='"""' skip='\\"\|\\{' contains=rcl
 
 " See also https://vi.stackexchange.com/questions/5966/ for why the `contains`
 " needs to end in `[]`.
-syn keyword rclBuiltin chars contains[] ends_with except filter flat_map fold get group_by join key_by keys len map parse_int remove_prefix remove_suffix replace reverse sort split split_lines starts_with std sum to_lowercase to_uppercase values
+syn keyword rclBuiltin chars contains[] empty_set ends_with except filter flat_map fold get group_by join key_by keys len map parse_int remove_prefix remove_suffix replace reverse sort split split_lines starts_with std sum to_lowercase to_uppercase values
 
 syn match   rclType '\<\(Any\|Bool\|Dict\|Int\|List\|Null\|Set\|String\|Void\)\>'
 

--- a/src/fmt_rcl.rs
+++ b/src/fmt_rcl.rs
@@ -106,9 +106,11 @@ fn value(v: &Value) -> Doc {
         Value::Int(i) => Doc::from(i.to_string()).with_markup(Markup::Number),
         Value::String(s) => string(s).with_markup(Markup::String),
         Value::List(vs) => list("[", "]", vs.iter()),
-        // TODO: An empty set should print as {}, that would be a non-idempotency,
-        // because {} is the empty dict. We could add a function `std.empty_set`,
-        // and format it as that?
+        Value::Set(vs) if vs.is_empty() => group! {
+            Doc::from("std").with_markup(Markup::Builtin)
+            Doc::SoftBreak
+            indent! { "." Doc::from("empty_set").with_markup(Markup::Builtin) }
+        },
         Value::Set(vs) => list("{", "}", vs.iter()),
         Value::Dict(vs) => dict(vs.iter()),
 

--- a/src/highlight.rs
+++ b/src/highlight.rs
@@ -15,6 +15,7 @@ use crate::markup::{Markup, MarkupString};
 const BUILTINS: &[&str] = &[
     "chars",
     "contains",
+    "empty_set",
     "ends_with",
     "enumerate",
     "except",

--- a/src/stdlib.rs
+++ b/src/stdlib.rs
@@ -108,6 +108,7 @@ fn builtin_std_range(_eval: &mut Evaluator, call: FunctionCall) -> Result<Value>
 pub fn initialize() -> Value {
     let mut builtins: BTreeMap<Value, Value> = BTreeMap::new();
 
+    builtins.insert("empty_set".into(), Value::Set(Rc::new(BTreeSet::new())));
     builtins.insert("range".into(), Value::BuiltinFunction(&STD_RANGE));
     builtins.insert(
         "read_file_utf8".into(),


### PR DESCRIPTION
It started to get annoying to have to define it myself every time, so let's just add it properly now. This also resolves the longstanding issue in the RCL pretty-printer that we have no good way to print the empty set — now we do!

 * [x] Ensure documentation is up to date
 * [x] Ensure changelog is up to date
 * [x] Ensure test coverage
 * [x] Ensure fuzzers discover new code paths
 * [x] Ensure grammars and fuzz dictionary are up to date
