### PR TITLE
Add `all` and `any` methods on `List` and `Set`

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -16,8 +16,10 @@ compatibility impact will be clearly marked as such in the changelog.
 
 ## Unreleased
 
- * Add [`List.sort`](type_list.md#sort) method.
  * Add [`std.empty_set`](stdlib.md#empty_set) constant.
+ * Add [`List.sort`](type_list.md#sort) method.
+ * Add [`List.all`](type_list.md#all), [`List.any`](type_list.md#any),
+   [`Set.all`](type_set.md#all), and [`Set.any`](type_set.md#any) methods.
 
 ## 0.6.0
 

--- a/docs/type_list.md
+++ b/docs/type_list.md
@@ -2,6 +2,50 @@
 
 The `List` type has the following methods.
 
+## all
+
+```rcl
+List.all: (self: List[T], predicate: T -> Bool) -> Bool
+```
+
+Return whether the predicate is true for all elements in the list. For example:
+
+```rcl
+// Evaluates to true.
+[11, 17, 42].all(x => x > 0)
+
+// Evaluates to false.
+[11, 17, 42].all(x => x > 20)
+
+// Evaluates to true.
+[].all(x => false)
+```
+
+This method short-circuits: when the outcome is decided, it will not call the
+predicate for the remaining elements in the list.
+
+## any
+
+```rcl
+List.any: (self: List[T], predicate: T -> Bool) -> Bool
+```
+
+Return whether the predicate is true for any element in the list. For example:
+
+```rcl
+// Evaluates to true.
+[11, 17, 42].any(x => x > 17)
+
+// Evaluates to false.
+[11, 17, 42].any(x => x > 42)
+
+// Evaluates to false.
+[].any(x => true)
+```
+
+This method short-circuits: when the outcome is decided, it will not call the
+predicate for the remaining elements in the list.
+
 ## contains
 
 ```rcl

--- a/docs/type_set.md
+++ b/docs/type_set.md
@@ -2,6 +2,52 @@
 
 The `Set` type has the following methods.
 
+## all
+
+```rcl
+Set.all: (self: Set[T], predicate: T -> Bool) -> Bool
+```
+
+Return whether the predicate is true for all elements in the set. For example:
+
+```rcl
+// Evaluates to true.
+{11, 17, 42}.all(x => x > 0)
+
+// Evaluates to false.
+{11, 17, 42}.all(x => x > 20)
+
+// Evaluates to true.
+// TODO: Define std.empty_set
+std.empty_set.all(x => false)
+```
+
+This method short-circuits: when the outcome is decided, it will not call the
+predicate for the remaining elements in the set.
+
+## any
+
+```rcl
+Set.any: (self: Set[T], predicate: T -> Bool) -> Bool
+```
+
+Return whether the predicate is true for any element in the set. For example:
+
+```rcl
+// Evaluates to true.
+{11, 17, 42}.any(x => x > 17)
+
+// Evaluates to false.
+{11, 17, 42}.any(x => x > 42)
+
+// Evaluates to false.
+// TODO: Define std.empty_set
+std.empty_set.any(x => true)
+```
+
+This method short-circuits: when the outcome is decided, it will not call the
+predicate for the remaining elements in the set.
+
 ## contains
 
 ```rcl

--- a/docs/type_set.md
+++ b/docs/type_set.md
@@ -18,7 +18,6 @@ Return whether the predicate is true for all elements in the set. For example:
 {11, 17, 42}.all(x => x > 20)
 
 // Evaluates to true.
-// TODO: Define std.empty_set
 std.empty_set.all(x => false)
 ```
 
@@ -41,7 +40,6 @@ Return whether the predicate is true for any element in the set. For example:
 {11, 17, 42}.any(x => x > 42)
 
 // Evaluates to false.
-// TODO: Define std.empty_set
 std.empty_set.any(x => true)
 ```
 

--- a/fuzz/dictionary.txt
+++ b/fuzz/dictionary.txt
@@ -45,6 +45,8 @@
 "0x7fffffffffffffff"
 
 # Builtin methods.
+"all"
+"any"
 "chars"
 "contains"
 "empty_set"

--- a/fuzz/src/smith.rs
+++ b/fuzz/src/smith.rs
@@ -28,6 +28,8 @@ use crate::uber::Mode;
 /// Names of built-in variables and methods.
 const BUILTINS: &[&str] = &[
     // Methods
+    "all",
+    "any",
     "chars",
     "contains",
     "ends_with",

--- a/golden/error/std_list_any_inner_error.test
+++ b/golden/error/std_list_any_inner_error.test
@@ -1,0 +1,20 @@
+[1, 2, 3].any(x => assert x != 2, "Inner error!"; false)
+
+# output:
+stdin:1:27
+  ╷
+1 │ [1, 2, 3].any(x => assert x != 2, "Inner error!"; false)
+  ╵                           ^~~~~~
+Error: Assertion failed. Inner error!
+
+stdin:1:15
+  ╷
+1 │ [1, 2, 3].any(x => assert x != 2, "Inner error!"; false)
+  ╵               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+In internal call to predicate from 'List.any'.
+
+stdin:1:14
+  ╷
+1 │ [1, 2, 3].any(x => assert x != 2, "Inner error!"; false)
+  ╵              ^
+In call to method 'List.any'.

--- a/golden/error/std_list_any_not_bool.test
+++ b/golden/error/std_list_any_not_bool.test
@@ -1,0 +1,14 @@
+[1, 2, 3].any(x => x)
+
+# output:
+stdin:1:15
+  ╷
+1 │ [1, 2, 3].any(x => x)
+  ╵               ^~~~~~
+Error: Type mismatch. Expected predicate for 'List.any' to return Bool, but it returned 1.
+
+stdin:1:14
+  ╷
+1 │ [1, 2, 3].any(x => x)
+  ╵              ^
+In call to method 'List.any'.

--- a/golden/rcl/list_all.test
+++ b/golden/rcl/list_all.test
@@ -1,0 +1,10 @@
+{
+  a = [].all(x => x),
+  b = [1, 2, 3].all(x => x > 2),
+  c = [1, 2, 3].all(x => x > 0),
+  // The assertion is never hit, we never evaluate the predicate on the third element.
+  d = [1, 2, 3].all(x => assert x != 3, "'any' short-circuits."; x < 2),
+}
+
+# output:
+{ a = true, b = false, c = true, d = false }

--- a/golden/rcl/list_any.test
+++ b/golden/rcl/list_any.test
@@ -1,0 +1,10 @@
+{
+  a = [].any(x => x),
+  b = [1, 2, 3].any(x => x > 2),
+  c = [1, 2, 3].any(x => x > 10),
+  // The assertion is never hit, we never evaluate the predicate on the third element.
+  d = [1, 2, 3].any(x => assert x < 3, "'any' short-circuits."; x > 1),
+}
+
+# output:
+{ a = false, b = true, c = false, d = true }

--- a/golden/rcl/set_all.test
+++ b/golden/rcl/set_all.test
@@ -1,0 +1,11 @@
+{
+  let empty_set: Set[Void] = {};
+  a = empty_set.all(x => x),
+  b = {1, 2, 3}.all(x => x > 2),
+  c = {1, 2, 3}.all(x => x > 0),
+  // The assertion is never hit, we never evaluate the predicate on the third element.
+  d = {1, 2, 3}.all(x => assert x != 3, "'any' short-circuits."; x < 2),
+}
+
+# output:
+{ a = true, b = false, c = true, d = false }

--- a/golden/rcl/set_all.test
+++ b/golden/rcl/set_all.test
@@ -1,6 +1,5 @@
 {
-  let empty_set: Set[Void] = {};
-  a = empty_set.all(x => x),
+  a = std.empty_set.all(x => x),
   b = {1, 2, 3}.all(x => x > 2),
   c = {1, 2, 3}.all(x => x > 0),
   // The assertion is never hit, we never evaluate the predicate on the third element.

--- a/golden/rcl/set_any.test
+++ b/golden/rcl/set_any.test
@@ -1,0 +1,11 @@
+{
+  let empty_set: Set[Void] = {};
+  a = empty_set.any(x => x),
+  b = {1, 2, 3}.any(x => x > 2),
+  c = {1, 2, 3}.any(x => x > 10),
+  // The assertion is never hit, we never evaluate the predicate on the third element.
+  d = {1, 2, 3}.any(x => assert x < 3, "'any' short-circuits."; x > 1),
+}
+
+# output:
+{ a = false, b = true, c = false, d = true }

--- a/golden/rcl/set_any.test
+++ b/golden/rcl/set_any.test
@@ -1,6 +1,5 @@
 {
-  let empty_set: Set[Void] = {};
-  a = empty_set.any(x => x),
+  a = std.empty_set.any(x => x),
   b = {1, 2, 3}.any(x => x > 2),
   c = {1, 2, 3}.any(x => x > 10),
   // The assertion is never hit, we never evaluate the predicate on the third element.

--- a/grammar/pygments/rcl.py
+++ b/grammar/pygments/rcl.py
@@ -60,6 +60,8 @@ _root_base = [
     (
         words(
             (
+                "all",
+                "any",
                 "chars",
                 "contains",
                 "empty_set",

--- a/grammar/rcl.vim/syntax/rcl.vim
+++ b/grammar/rcl.vim/syntax/rcl.vim
@@ -45,7 +45,7 @@ syn region  rclFormatTriple  start='f"""' end='"""' skip='\\"\|\\{' contains=rcl
 
 " See also https://vi.stackexchange.com/questions/5966/ for why the `contains`
 " needs to end in `[]`.
-syn keyword rclBuiltin chars contains[] empty_set ends_with except filter flat_map fold get group_by join key_by keys len map parse_int remove_prefix remove_suffix replace reverse sort split split_lines starts_with std sum to_lowercase to_uppercase values
+syn keyword rclBuiltin all any chars contains[] empty_set ends_with except filter flat_map fold get group_by join key_by keys len map parse_int remove_prefix remove_suffix replace reverse sort split split_lines starts_with std sum to_lowercase to_uppercase values
 
 syn match   rclType '\<\(Any\|Bool\|Dict\|Int\|List\|Null\|Set\|String\|Void\)\>'
 

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -448,6 +448,8 @@ impl<'a> Evaluator<'a> {
                     (Value::List(_), "sort") => Some(&stdlib::LIST_SORT),
                     (Value::List(_), "sum") => Some(&stdlib::LIST_SUM),
 
+                    (Value::Set(_), "all") => Some(&stdlib::SET_ALL),
+                    (Value::Set(_), "any") => Some(&stdlib::SET_ANY),
                     (Value::Set(_), "contains") => Some(&stdlib::SET_CONTAINS),
                     (Value::Set(_), "except") => Some(&stdlib::SET_EXCEPT),
                     (Value::Set(_), "filter") => Some(&stdlib::SET_FILTER),

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -432,6 +432,8 @@ impl<'a> Evaluator<'a> {
                         };
                     }
 
+                    (Value::List(_), "all") => Some(&stdlib::LIST_ALL),
+                    (Value::List(_), "any") => Some(&stdlib::LIST_ANY),
                     (Value::List(_), "contains") => Some(&stdlib::LIST_CONTAINS),
                     (Value::List(_), "enumerate") => Some(&stdlib::LIST_ENUMERATE),
                     (Value::List(_), "filter") => Some(&stdlib::LIST_FILTER),

--- a/src/highlight.rs
+++ b/src/highlight.rs
@@ -13,6 +13,8 @@ use crate::markup::{Markup, MarkupString};
 // TODO: These are now unused. Bring back highlighting of builtins.
 #[allow(dead_code)]
 const BUILTINS: &[&str] = &[
+    "all",
+    "any",
     "chars",
     "contains",
     "empty_set",

--- a/src/stdlib.rs
+++ b/src/stdlib.rs
@@ -756,13 +756,13 @@ builtin_method!(
     builtin_set_all
 );
 fn builtin_set_all(eval: &mut Evaluator, call: MethodCall) -> Result<Value> {
-    let list = call.receiver.expect_list();
+    let elems = call.receiver.expect_set();
     Ok(Value::Bool(builtin_all_any_impl(
         eval,
         call,
         "Set.all",
         AllAny::All,
-        list,
+        elems,
     )?))
 }
 
@@ -773,13 +773,13 @@ builtin_method!(
     builtin_set_any
 );
 fn builtin_set_any(eval: &mut Evaluator, call: MethodCall) -> Result<Value> {
-    let list = call.receiver.expect_list();
+    let elems = call.receiver.expect_set();
     Ok(Value::Bool(builtin_all_any_impl(
         eval,
         call,
         "Set.any",
         AllAny::Any,
-        list,
+        elems,
     )?))
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -725,7 +725,7 @@ pub fn builtin(type_: Type) -> SourcedType {
 /// * `List[T]` is written `[T]`.
 /// * `Set[T]` is written `{T}`.
 /// * `Dict[K, V]` is written `{K: V}`.
-/// * `(P, Q) -> R` is written `(fn (P, Q) -> R)`
+/// * `(p: P, q: Q) -> R` is written `(fn (p: P, q: Q) -> R)`
 macro_rules! make_type {
     (Any) => { builtin(Type::Any) };
     (Int) => { builtin(Type::Int) };


### PR DESCRIPTION
For convenience, you could already do it with a fold. I hesitated between

1. `List.all: (self: List[Bool]) -> Bool`
2. `List.all: (self: List[T], predicate: T -> Bool) -> Bool`

but went for the second option in the end for two reasons:

* You almost never write a list of booleans, you get a list of booleans by mapping some predicate over a different list. So we may as well move the predicate inside.
* For type inference, this means that we don’t need to constrain type parameters on the receiver based on the method called. I expect this will make type inference simpler once we add type inference on method calls, though I haven’t thought very deeply about it.

<!-- -->

 * [x] Ensure documentation is up to date
 * [x] Ensure changelog is up to date
 * [x] Ensure test coverage
 * [x] Ensure fuzzers discover new code paths
 * [x] Ensure grammars and fuzz dictionary are up to date
