### PR TITLE
Pin cloudflare DNS record example link

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -438,7 +438,7 @@
       We have to create two very similar DNS records pointing to that server’s address.
       One way to manage those is with Terraform/OpenTofu.
       The output below is a
-      <a href="https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/record">simplified form</a>
+      <a href="https://registry.terraform.io/providers/cloudflare/cloudflare/4.49.1/docs/resources/record">simplified form</a>
       of a
       <a href="https://opentofu.org/docs/language/syntax/json/">json config</a>
       that defines the records.</p>


### PR DESCRIPTION
It appears that Cloudflare module for Terraform is experiencing and API change in v5 [0]. The v5 is only in alpha release now, so I'm not sure how long it will take to reach the release.

Pinning the link to 4.49.1 is a workaround for the time being.

For v5, the relevant at the moment page is [1].

0:
https://registry.terraform.io/providers/cloudflare/cloudflare/latest

1:
https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/dns_record