### PR TITLE
Implement `Number.round`

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -33,7 +33,8 @@ Release highlights:
    likely change in a future version.
  * When running `rcl` without arguments, it now prints only the most important
    parts of the help text. Use `rcl --help` for the full command reference.
- * Add [`List.sort_by`(type_list.md#sort_by) and
+ * Add [`Number.round`](type_number.md#round) method.
+ * Add [`List.sort_by`](type_list.md#sort_by) and
    [`Set.sort_by`](type_set.md#sort_by) methods.
  * Add [`Set.sort`](type_set.md#sort) method for symmetry with `List`.
 

--- a/docs/type_number.md
+++ b/docs/type_number.md
@@ -54,18 +54,17 @@ This limitation should be lifted in a future version.
 Number.round: (self: Number, n_decimals: Number) -> Number
 ```
 
-TODO: This function does not actually exist yet.
-
-Round the number to `n_decimals` decimal places. When `n_decimals` is 0, the
-result is an integer. When `n_decimals` is negative, this rounds to powers of 10.
+Round the number to `n_decimals` decimal places. The result is not in scientific
+notation (it has no exponent), even when the input is. When `n_decimals` is 0,
+this means that the result is an integer. This rounds away from 0.
 
 ```rcl
 // Evaluates to 0.4.
 (0.42).round(1)
 
-// Evaluates to 42.
-(41.5).round(0)
+// Evaluates to [42, -42].
+[(41.5).round(0), (-41.5).round(0)]
 
-// Evaluates to 4e1.
-(42).round(-1)
+// Evaluates to 4200.
+(42e2).round(0)
 ```

--- a/fuzz/dictionary.txt
+++ b/fuzz/dictionary.txt
@@ -68,6 +68,7 @@
 "remove_suffix"
 "replace"
 "reverse"
+"round"
 "sort"
 "sort_by"
 "split"

--- a/fuzz/src/smith.rs
+++ b/fuzz/src/smith.rs
@@ -50,6 +50,7 @@ const BUILTINS: &[&str] = &[
     "remove_suffix",
     "replace",
     "reverse",
+    "round",
     "sort",
     "sort_by",
     "split",

--- a/golden/error/runtime_overflow_add_2.test
+++ b/golden/error/runtime_overflow_add_2.test
@@ -1,0 +1,11 @@
+// This is a regression test for a crash caught by the fuzzer.
+// It used to overflow a subtraction in decimal.rs, where it subtracts
+// the exponents.
+77E-19263+7E19238
+
+# output:
+stdin:4:10
+  ╷
+4 │ 77E-19263+7E19238
+  ╵          ^
+Error: Addition 77e-19263 + 7e19238 would overflow.

--- a/golden/error/std_number_round_negative.test
+++ b/golden/error/std_number_round_negative.test
@@ -1,0 +1,14 @@
+[1.0.round(0), 1.0.round(-1)]
+
+# output:
+stdin:1:26
+  ╷
+1 │ [1.0.round(0), 1.0.round(-1)]
+  ╵                          ^~
+Error: Can't round to negative decimals, decimals must be at least 0.
+
+stdin:1:25
+  ╷
+1 │ [1.0.round(0), 1.0.round(-1)]
+  ╵                         ^
+In call to method 'Number.round'.

--- a/golden/error/std_number_round_too_large.test
+++ b/golden/error/std_number_round_too_large.test
@@ -1,0 +1,15 @@
+// 100 decimals is the most we support.
+[1e-90.round(100), 1e-90.round(101)]
+
+# output:
+stdin:2:32
+  ╷
+2 │ [1e-90.round(100), 1e-90.round(101)]
+  ╵                                ^~~
+Error: Number of decimals can be at most 100.
+
+stdin:2:31
+  ╷
+2 │ [1e-90.round(100), 1e-90.round(101)]
+  ╵                               ^
+In call to method 'Number.round'.

--- a/golden/error/std_range_not_int_0.test
+++ b/golden/error/std_range_not_int_0.test
@@ -5,7 +5,7 @@ stdin:1:11
   ╷
 1 │ std.range("not int", 10)
   ╵           ^~~~~~~~~
-Error: Expected an integer, but got "not int".
+Error: Expected lower bound to be integer, but got "not int".
 
 stdin:1:10
   ╷

--- a/golden/error/std_range_not_int_1.test
+++ b/golden/error/std_range_not_int_1.test
@@ -5,7 +5,7 @@ stdin:1:14
   ╷
 1 │ std.range(0, "not int")
   ╵              ^~~~~~~~~
-Error: Expected an integer, but got "not int".
+Error: Expected upper bound to be integer, but got "not int".
 
 stdin:1:10
   ╷

--- a/golden/error/std_range_not_int_1a.test
+++ b/golden/error/std_range_not_int_1a.test
@@ -7,7 +7,7 @@ stdin:3:16
   ╷
 3 │ std.range(0.0, 1.5)
   ╵                ^~~
-Error: Expected an integer, but got 1.5.
+Error: Expected upper bound to be integer, but got 1.5.
 
 stdin:3:10
   ╷

--- a/golden/rcl/number_round.test
+++ b/golden/rcl/number_round.test
@@ -1,0 +1,51 @@
+[
+  // Cases where we have to add decimals.
+  (0).round(3),
+  1.1.round(3),
+
+  // We fold the exponent into the result.
+  1e2.round(3),
+  1.1e1.round(3),
+
+  // Cases where we have to remove decimals.
+  1.000.round(0),
+  1.000.round(1),
+  1.499.round(1),
+  1.501.round(1),
+  (-1.499).round(1),
+  (-1.501).round(1),
+
+  // We round 0.5 away from zero.
+  1.499.round(0),
+  1.500.round(0),
+  1.501.round(0),
+  (-1.499).round(0),
+  (-1.500).round(0),
+  (-1.501).round(0),
+
+  // The i64 mantissa does not have more than 18 (or for a limited range, 19)
+  // decimal digits of precision, but we can still round to more than 18
+  // decimals, as long as there are fewer than 19 significant digits.
+  42e-20.round(22)
+]
+
+# output:
+[
+  0.000,
+  1.100,
+  100.000,
+  11.000,
+  1,
+  1.0,
+  1.5,
+  1.5,
+  -1.5,
+  -1.5,
+  1,
+  2,
+  2,
+  -1,
+  -2,
+  -2,
+  0.0000000000000000004200,
+]

--- a/grammar/pygments/rcl.py
+++ b/grammar/pygments/rcl.py
@@ -83,6 +83,7 @@ _root_base = [
                 "remove_suffix",
                 "replace",
                 "reverse",
+                "round",
                 "sort",
                 "sort_by",
                 "split",

--- a/grammar/rcl.vim/syntax/rcl.vim
+++ b/grammar/rcl.vim/syntax/rcl.vim
@@ -45,7 +45,7 @@ syn region  rclFormatTriple  start='f"""' end='"""' skip='\\"\|\\{' contains=rcl
 
 " See also https://vi.stackexchange.com/questions/5966/ for why the `contains`
 " needs to end in `[]`.
-syn keyword rclBuiltin all any chars contains[] empty_set ends_with except filter flat_map fold get group_by join key_by keys len map parse_int remove_prefix remove_suffix replace reverse sort sort_by split split_lines starts_with std sum to_lowercase to_uppercase values
+syn keyword rclBuiltin all any chars contains[] empty_set ends_with except filter flat_map fold get group_by join key_by keys len map parse_int remove_prefix remove_suffix replace reverse round sort sort_by split split_lines starts_with std sum to_lowercase to_uppercase values
 
 syn match   rclType '\<\(Any\|Bool\|Dict\|List\|Null\|Number\|Set\|String\|Union\|Void\)\>'
 

--- a/src/decimal.rs
+++ b/src/decimal.rs
@@ -229,7 +229,10 @@ impl Decimal {
             std::mem::swap(&mut d1, &mut d2);
         }
         if d1.exponent < d2.exponent {
-            let f = 10_i64.checked_pow((d2.exponent - d1.exponent) as u32)?;
+            // We know d2 > d1, so d2 - d1 is positive, but the difference may
+            // not fit in an i16 when d2 is close to i16::MAX and d1 is close to
+            // i16::MIN, so widen to i32 before subtracting.
+            let f = 10_i64.checked_pow((d2.exponent as i32 - d1.exponent as i32) as u32)?;
             d2.mantissa = d2.mantissa.checked_mul(f)?;
             d2.exponent = d1.exponent;
         }

--- a/src/decimal.rs
+++ b/src/decimal.rs
@@ -295,6 +295,48 @@ impl Decimal {
         Some(result)
     }
 
+    /// Round the number to the nearest multiple of 10^{-n_decimals}.
+    ///
+    /// This moves the exponent into the mantissa, so the result always has the
+    /// exponent set to 0. This means that round is not that useful beyond the
+    /// range of an i64, but that's fine for now.
+    ///
+    /// Returns `None` on overflow.
+    pub fn round(&self, n_decimals: u8) -> Option<Decimal> {
+        match n_decimals as i32 - self.decimals as i32 + self.exponent as i32 {
+            // The number already has exactly the requested number of decimals.
+            0 => Some(*self),
+
+            // We have to add additional decimals. The maximum power of 2 we can
+            // represent is 2^18, beyond that we will certainly get overflow.
+            d if d > 0 && d <= 18 => {
+                let f = 10_i64.pow(d as u32);
+                let result = Decimal {
+                    mantissa: self.mantissa.checked_mul(f)?,
+                    exponent: 0,
+                    decimals: n_decimals,
+                };
+                Some(result)
+            }
+
+            // d is negative, we have to remove decimals.
+            d if d < 0 && d >= -18 => {
+                let f = 10_i64.pow((-d) as u32);
+                let b = if self.mantissa > 0 { f / 2 } else { -f / 2 };
+                let result = Decimal {
+                    mantissa: self.mantissa.saturating_add(b) / f,
+                    exponent: 0,
+                    decimals: n_decimals,
+                };
+                Some(result)
+            }
+
+            // Overflow in either direction. The result wouldn't fit the i64
+            // range of the mantissa.
+            _ => None,
+        }
+    }
+
     /// Convert to a float. For many decimals this will be a lossy operation.
     pub fn to_f64_lossy(&self) -> f64 {
         let n = self.mantissa as f64;

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -405,6 +405,8 @@ impl<'a> Evaluator<'a> {
                     (Value::String(_), "to_lowercase") => Some(&stdlib::STRING_TO_LOWERCASE),
                     (Value::String(_), "to_uppercase") => Some(&stdlib::STRING_TO_UPPERCASE),
 
+                    (Value::Number(_), "round") => Some(&stdlib::NUMBER_ROUND),
+
                     (Value::Dict(_), "contains") => Some(&stdlib::DICT_CONTAINS),
                     (Value::Dict(_), "except") => Some(&stdlib::DICT_EXCEPT),
                     (Value::Dict(_), "get") => Some(&stdlib::DICT_GET),

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -187,6 +187,15 @@ impl Value {
         }
     }
 
+    /// Extract a number if the value is a number, panic otherwise.
+    #[inline]
+    pub fn expect_number(&self) -> &Decimal {
+        match self {
+            Value::Number(d) => d,
+            other => panic!("Expected Number but got {other:?}."),
+        }
+    }
+
     /// Extract the dict if it is one, panic otherwise.
     #[inline]
     pub fn expect_dict(&self) -> &BTreeMap<Value, Value> {

--- a/src/stdlib.rs
+++ b/src/stdlib.rs
@@ -45,6 +45,23 @@ fn builtin_std_read_file_utf8(eval: &mut Evaluator, call: FunctionCall) -> Resul
     Ok(eval.loader.get_doc(doc).data.into())
 }
 
+/// Extract an i64 from a call argument, or return an error if it's not an integer.
+fn expect_arg_i64(arg: &CallArg<Value>, arg_name: &'static str) -> Result<i64> {
+    match arg.value.to_i64() {
+        Some(n) => Ok(n),
+        None => arg
+            .span
+            .error(concat! {
+                "Expected "
+                arg_name
+                " to be integer, but got "
+                format_rcl(&arg.value).into_owned()
+                "."
+            })
+            .err(),
+    }
+}
+
 builtin_function!(
     "std.range",
     (lower: Number, upper: Number) -> [Number],
@@ -52,20 +69,8 @@ builtin_function!(
     builtin_std_range
 );
 fn builtin_std_range(_eval: &mut Evaluator, call: FunctionCall) -> Result<Value> {
-    let expect_i64 = |arg: &CallArg<Value>| match arg.value.to_i64() {
-        Some(n) => Ok(n),
-        None => arg
-            .span
-            .error(concat! {
-                "Expected an integer, but got "
-                format_rcl(&arg.value).into_owned()
-                "."
-            })
-            .err(),
-    };
-
-    let lower: i64 = expect_i64(&call.args[0])?;
-    let upper: i64 = expect_i64(&call.args[1])?;
+    let lower: i64 = expect_arg_i64(&call.args[0], "lower bound")?;
+    let upper: i64 = expect_arg_i64(&call.args[1], "upper bound")?;
     let range = lower..upper;
 
     // Because we materialize the entire list, it's easy to cause out of memory
@@ -729,6 +734,45 @@ builtin_method!("Set.sum", () -> Number, const SET_SUM, builtin_set_sum);
 fn builtin_set_sum(_eval: &mut Evaluator, call: MethodCall) -> Result<Value> {
     let set = call.receiver.expect_set();
     builtin_sum_impl(call, set)
+}
+
+builtin_method!(
+    "Number.round",
+    (n_decimals: Number) -> Number,
+    const NUMBER_ROUND,
+    builtin_number_round
+);
+fn builtin_number_round(_eval: &mut Evaluator, call: MethodCall) -> Result<Value> {
+    let arg = &call.call.args[0];
+    let n_decimals = expect_arg_i64(arg, "number of decimals")?;
+
+    if n_decimals < 0 {
+        return arg
+            .span
+            .error("Can't round to negative decimals, decimals must be at least 0.")
+            .err();
+    }
+    if n_decimals > 100 {
+        // The representation allows up to 255 decimals, but we also have this
+        // property that RCL should be able to read its own output, and we have
+        // a limit on the length of number literals. If we allow 255 decimals,
+        // the formatted number can exceed that limit. Given that we have an
+        // arbitrary limit anyway, and that even 50 decimals would be silly, I
+        // think a limit of 100 decimals should be fine. RCL is not an arbitrary
+        // precision calculator, use a different language if you need that many
+        // decimals.
+        return arg
+            .span
+            .error("Number of decimals can be at most 100.")
+            .err();
+    }
+    match call.receiver.expect_number().round(n_decimals as u8) {
+        Some(d) => Ok(Value::Number(d)),
+        None => call
+            .method_span
+            .error("Overflow while rounding number.")
+            .err(),
+    }
 }
 
 /// Which function to implement in [`builtin_any_all_impl`].


### PR DESCRIPTION
I documented it when I added the `Number` type, and it’s not _that_ hard to add, so let's add it. Because numbers preserve their number of decimals, this is also the way to get control over how they are formatted in the output. With strings you could e.g. adopt Python-like `f{x:.3f}` to splice in the number with a fixed 3 decimal digits, but what to do when the output is a number and not a string? Now you can `x.round(3)`, and for the formatting case that works too.

 * [x] Ensure documentation is up to date
 * [x] Ensure changelog is up to date
 * [x] Ensure test coverage
 * [ ] Ensure fuzzers discover new code paths
 * [ ] Ensure grammars and fuzz dictionary are up to date
