### PR TITLE
Change assertion separator from comma to colon

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -20,6 +20,13 @@ Unreleased.
 
  * [Prebuilt binaries](installation.md#prebuilt-binaries) are now available for
    several platforms. They are hosted [on Github](https://github.com/ruuda/rcl/releases).
+ * [Assertions](syntax.md#assertions) now use a `:` to separate the condition
+   and the message, i.e. `assert cond: "message";` rather than
+   `assert cond, "message";`. The standard formatting for assertions that do not
+   fit on a single line is now like `if` expressions, rather than like function
+   calls. For compatibility, a comma is still accepted for now. This will likely
+   change in a future release. In that case it will be clearly marked as a
+   change with compatibility impact in the release notes.
 
 ## 0.10.0
 

--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -385,13 +385,13 @@ You can use assertions in expressions and inside comprehensions:
 
 ```rcl
 // Expression form:
-assert condition, "Message for when the assertion fails.";
+assert condition: "Message for when the assertion fails.";
 body
 
 // Comprehension form:
 [
   for widget in widgets:
-  assert widget.is_valid(), f"Widget {widget.id} is invalid.";
+  assert widget.is_valid(): f"Widget {widget.id} is invalid.";
   widget
 ]
 ```

--- a/fuzz/src/smith.rs
+++ b/fuzz/src/smith.rs
@@ -126,7 +126,7 @@ define_ops! {
     0x50 => ExprLet,
     /// Replace the top 2 elements with `let {0}: {T} = {0}; {1}`.
     0x51 => ExprTypedLet,
-    /// Replace the top 3 elements with `assert {0}, {1}; {2}`.
+    /// Replace the top 3 elements with `assert {0}: {1}; {2}`.
     0x52 => ExprAssert,
     /// Replace the top 2 elements with `trace {0}; {2}`.
     0x53 => ExprTrace,
@@ -451,7 +451,7 @@ impl<'a> ProgramBuilder<'a> {
                 let message = self.expr_stack.pop()?;
                 let body = self.expr_stack.pop()?;
                 self.expr_stack
-                    .push(format!("assert {condition}, {message}; {body}"));
+                    .push(format!("assert {condition}: {message}; {body}"));
             }
             Op::ExprTrace => {
                 let message = self.expr_stack.pop()?;

--- a/golden/cmd/highlight_html.test
+++ b/golden/cmd/highlight_html.test
@@ -1,12 +1,12 @@
 # command: ["highlight", "--color=html"]
 // Comment.
 let a: Number = 1;
-assert a == 1, f"{a} is a number \u{2026}";
+assert a == 1: f"{a} is a number \u{2026}";
 [for x in std.range(0, 0xff): a]
 
 # output:
 <pre><code class="sourceCode"><span class="co">// Comment.</span>
 <span class="kw">let</span> <span class="n">a</span>: <span class="n">Number</span> = <span class="dv">1</span>;
-<span class="kw">assert</span> <span class="n">a</span> == <span class="dv">1</span>, <span class="st">f"</span><span class="dt">{</span><span class="n">a</span><span class="dt">}</span><span class="st"> is a number </span><span class="dt">\u{2026}</span><span class="st">"</span>;
+<span class="kw">assert</span> <span class="n">a</span> == <span class="dv">1</span>: <span class="st">f"</span><span class="dt">{</span><span class="n">a</span><span class="dt">}</span><span class="st"> is a number </span><span class="dt">\u{2026}</span><span class="st">"</span>;
 [<span class="kw">for</span> <span class="n">x</span> <span class="kw">in</span> <span class="n">std</span>.<span class="n">range</span>(<span class="dv">0</span>, <span class="dv">0xff</span>): <span class="n">a</span>]
 </code></pre>

--- a/golden/error/parse_assert_no_colon.test
+++ b/golden/error/parse_assert_no_colon.test
@@ -1,0 +1,9 @@
+assert false
+0
+
+# output:
+stdin:2:1
+  ╷
+2 │ 0
+  ╵ ^
+Error: Expected ':' here between the assertion condition and message.

--- a/golden/error/parse_assert_no_comma.test
+++ b/golden/error/parse_assert_no_comma.test
@@ -1,9 +1,0 @@
-assert false
-0
-
-# output:
-stdin:2:1
-  ╷
-2 │ 0
-  ╵ ^
-Error: Expected ',' here between the assertion condition and message.

--- a/golden/error/parse_assert_semicolon.test
+++ b/golden/error/parse_assert_semicolon.test
@@ -6,6 +6,6 @@ stdin:1:13
   ╷
 1 │ assert false;
   ╵             ^
-Error: Expected ',' here between the assertion condition and message.
+Error: Expected ':' here between the assertion condition and message.
 
-Help: An assertion has the form 'assert <condition>, <message>;'. The message is not optional.
+Help: An assertion has the form 'assert <condition>: <message>;'. The message is not optional.

--- a/golden/error/runtime_assertion_failure.test
+++ b/golden/error/runtime_assertion_failure.test
@@ -1,10 +1,10 @@
-assert true, "This assertion should pass.";
-assert false, "This assertion should fail.";
+assert true: "This assertion should pass.";
+assert false: "This assertion should fail.";
 0
 
 # output:
 stdin:2:8
   ╷
-2 │ assert false, "This assertion should fail.";
+2 │ assert false: "This assertion should fail.";
   ╵        ^~~~~
 Error: Assertion failed. This assertion should fail.

--- a/golden/error/runtime_assertion_failure_value.test
+++ b/golden/error/runtime_assertion_failure_value.test
@@ -1,10 +1,10 @@
-assert false, { message = "The message is not just a string.", value = 12 };
+assert false: { message = "The message is not just a string.", value = 12 };
 0
 
 # output:
 stdin:1:8
   ╷
-1 │ assert false, { message = "The message is not just a string.", value = 12 };
+1 │ assert false: { message = "The message is not just a string.", value = 12 };
   ╵        ^~~~~
 Error: Assertion failed. {
   message = "The message is not just a string.",

--- a/golden/error/runtime_assertion_with_newline.test
+++ b/golden/error/runtime_assertion_with_newline.test
@@ -1,13 +1,13 @@
 // A line break is not allowed in document fragments for the pretty-printer,
 // and printing assertion messages uses the pretty-printer, so it should break
 // the string into lines and not crash. This is a regression test.
-assert false, "This message\nhas a line break in it.";
+assert false: "This message\nhas a line break in it.";
 0
 
 # output:
 stdin:4:8
   ╷
-4 │ assert false, "This message\nhas a line break in it.";
+4 │ assert false: "This message\nhas a line break in it.";
   ╵        ^~~~~
 Error: Assertion failed. This message
 has a line break in it.

--- a/golden/error/std_list_any_inner_error.test
+++ b/golden/error/std_list_any_inner_error.test
@@ -1,20 +1,20 @@
-[1, 2, 3].any(x => assert x != 2, "Inner error!"; false)
+[1, 2, 3].any(x => assert x != 2: "Inner error!"; false)
 
 # output:
 stdin:1:27
   ╷
-1 │ [1, 2, 3].any(x => assert x != 2, "Inner error!"; false)
+1 │ [1, 2, 3].any(x => assert x != 2: "Inner error!"; false)
   ╵                           ^~~~~~
 Error: Assertion failed. Inner error!
 
 stdin:1:15
   ╷
-1 │ [1, 2, 3].any(x => assert x != 2, "Inner error!"; false)
+1 │ [1, 2, 3].any(x => assert x != 2: "Inner error!"; false)
   ╵               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 In internal call to predicate from 'List.any'.
 
 stdin:1:14
   ╷
-1 │ [1, 2, 3].any(x => assert x != 2, "Inner error!"; false)
+1 │ [1, 2, 3].any(x => assert x != 2: "Inner error!"; false)
   ╵              ^
 In call to method 'List.any'.

--- a/golden/error/std_list_map_error.test
+++ b/golden/error/std_list_map_error.test
@@ -1,20 +1,20 @@
-[1, 2, 3].map(x => assert false, "This crashes"; x)
+[1, 2, 3].map(x => assert false: "This crashes"; x)
 
 # output:
 stdin:1:27
   ╷
-1 │ [1, 2, 3].map(x => assert false, "This crashes"; x)
+1 │ [1, 2, 3].map(x => assert false: "This crashes"; x)
   ╵                           ^~~~~
 Error: Assertion failed. This crashes
 
 stdin:1:15
   ╷
-1 │ [1, 2, 3].map(x => assert false, "This crashes"; x)
+1 │ [1, 2, 3].map(x => assert false: "This crashes"; x)
   ╵               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 In internal call to mapping function from 'List.map'.
 
 stdin:1:14
   ╷
-1 │ [1, 2, 3].map(x => assert false, "This crashes"; x)
+1 │ [1, 2, 3].map(x => assert false: "This crashes"; x)
   ╵              ^
 In call to method 'List.map'.

--- a/golden/error_json/builtin_function_span.test
+++ b/golden/error_json/builtin_function_span.test
@@ -1,7 +1,7 @@
 // This tests that we blame the error on the innermost expression,
 // even when it is preceded by a statement.
 let method = "String".len;
-assert method() == 6, "The length of 'String' is 6.";
+assert method() == 6: "The length of 'String' is 6.";
 method
 
 # output:

--- a/golden/fmt/assert_trace.test
+++ b/golden/fmt/assert_trace.test
@@ -18,8 +18,7 @@ assert true, "The comma is allowed, for now.";
 assert true == true: "The two true booleans should be equal";
 trace "Some short message";
 
-assert
-  this_is_a_much_longer_assertion_that_does_not_fit():
+assert this_is_a_much_longer_assertion_that_does_not_fit():
   ["If you include its error message."];
 trace f"And this is a much longer trace message which has a hole in it {0} but nonetheless should not be line-wrapped.";
 

--- a/golden/fmt/assert_trace.test
+++ b/golden/fmt/assert_trace.test
@@ -1,22 +1,30 @@
-assert true == true, "The two true booleans should be equal";
+assert true == true: "The two true booleans should be equal";
 trace "Some short message";
 
-assert this_is_a_much_longer_assertion_that_does_not_fit(), [
+assert this_is_a_much_longer_assertion_that_does_not_fit(): [
   "If you include its error message."
 ];
 trace f"And this is a much longer trace message which has a hole in it {
 0
 } but nonetheless should not be line-wrapped.";
 
+// For historical reasons, assertions are allowed to use comma
+// in addition to colon, but the formatter always outputs colon.
+assert true, "The comma is allowed, for now.";
+
 0
 
 # output:
-assert true == true, "The two true booleans should be equal";
+assert true == true: "The two true booleans should be equal";
 trace "Some short message";
 
 assert
-  this_is_a_much_longer_assertion_that_does_not_fit(),
+  this_is_a_much_longer_assertion_that_does_not_fit():
   ["If you include its error message."];
 trace f"And this is a much longer trace message which has a hole in it {0} but nonetheless should not be line-wrapped.";
+
+// For historical reasons, assertions are allowed to use comma
+// in addition to colon, but the formatter always outputs colon.
+assert true: "The comma is allowed, for now.";
 
 0

--- a/golden/fmt/seq_atomic.test
+++ b/golden/fmt/seq_atomic.test
@@ -27,7 +27,7 @@ let multiline_tall = [
 // together.
 let stmts = [
   let xs = std.range(0, 100); trace xs;
-  for x in xs: if x > 50: assert x > 50, "that condition should work";
+  for x in xs: if x > 50: assert x > 50: "that condition should work";
   let ys = std.range(x, 100); for y in ys:
   x + y
 ];
@@ -59,7 +59,7 @@ let stmts = [
   trace xs;
   for x in xs:
   if x > 50:
-  assert x > 50, "that condition should work";
+  assert x > 50: "that condition should work";
   let ys = std.range(x, 100);
   for y in ys:
   x + y

--- a/golden/json/string_len.test
+++ b/golden/json/string_len.test
@@ -9,7 +9,7 @@ let strings = [
 ];
 [
   for s in strings:
-  assert s.len() == s.chars().len(), ["String.len counts chars.", s, s.chars()];
+  assert s.len() == s.chars().len(): ["String.len counts chars.", s, s.chars()];
   s.len()
 ]
 

--- a/golden/rcl/list_all.test
+++ b/golden/rcl/list_all.test
@@ -3,7 +3,7 @@
   b = [1, 2, 3].all(x => x > 2),
   c = [1, 2, 3].all(x => x > 0),
   // The assertion is never hit, we never evaluate the predicate on the third element.
-  d = [1, 2, 3].all(x => assert x != 3, "'any' short-circuits."; x < 2),
+  d = [1, 2, 3].all(x => assert x != 3: "'any' short-circuits."; x < 2),
 }
 
 # output:

--- a/golden/rcl/list_any.test
+++ b/golden/rcl/list_any.test
@@ -3,7 +3,7 @@
   b = [1, 2, 3].any(x => x > 2),
   c = [1, 2, 3].any(x => x > 10),
   // The assertion is never hit, we never evaluate the predicate on the third element.
-  d = [1, 2, 3].any(x => assert x < 3, "'any' short-circuits."; x > 1),
+  d = [1, 2, 3].any(x => assert x < 3: "'any' short-circuits."; x > 1),
 }
 
 # output:

--- a/golden/rcl/set_all.test
+++ b/golden/rcl/set_all.test
@@ -3,7 +3,7 @@
   b = {1, 2, 3}.all(x => x > 2),
   c = {1, 2, 3}.all(x => x > 0),
   // The assertion is never hit, we never evaluate the predicate on the third element.
-  d = {1, 2, 3}.all(x => assert x != 3, "'any' short-circuits."; x < 2),
+  d = {1, 2, 3}.all(x => assert x != 3: "'any' short-circuits."; x < 2),
 }
 
 # output:

--- a/golden/rcl/set_any.test
+++ b/golden/rcl/set_any.test
@@ -3,7 +3,7 @@
   b = {1, 2, 3}.any(x => x > 2),
   c = {1, 2, 3}.any(x => x > 10),
   // The assertion is never hit, we never evaluate the predicate on the third element.
-  d = {1, 2, 3}.any(x => assert x < 3, "'any' short-circuits."; x > 1),
+  d = {1, 2, 3}.any(x => assert x < 3: "'any' short-circuits."; x > 1),
 }
 
 # output:

--- a/golden/types/runtime_type_assert_not_bool.test
+++ b/golden/types/runtime_type_assert_not_bool.test
@@ -1,11 +1,11 @@
 let not_bool: Any = 0;
-assert not_bool, "We don't even get here";
+assert not_bool: "We don't even get here";
 null
 
 # output:
 stdin:2:8
   ╷
-2 │ assert not_bool, "We don't even get here";
+2 │ assert not_bool: "We don't even get here";
   ╵        ^~~~~~~~
 Error: Type mismatch. Expected a value that fits this type:
 

--- a/golden/types/static_assertion_not_bool.test
+++ b/golden/types/static_assertion_not_bool.test
@@ -1,10 +1,10 @@
-assert 0, "The condition should be a boolean.";
+assert 0: "The condition should be a boolean.";
 0
 
 # output:
 stdin:1:8
   ╷
-1 │ assert 0, "The condition should be a boolean.";
+1 │ assert 0: "The condition should be a boolean.";
   ╵        ^
 Error: Type mismatch. Expected Bool but found Number.
 

--- a/golden/types/static_call_arity_missing_arg_unnamed.test
+++ b/golden/types/static_call_arity_missing_arg_unnamed.test
@@ -7,7 +7,7 @@ let g: (Any) -> Number = f;
 
 // This assertion would crash the program if we ever got to runtime. But the
 // arity error below should be detected at typecheck time already.
-assert false, "This should fail statically before it fails at runtime.";
+assert false: "This should fail statically before it fails at runtime.";
 
 // Now when we call `g`, we can infer from the type that we are passing too few
 // arguments, but we can't name the missing argument.

--- a/grammar/bison/grammar.y
+++ b/grammar/bison/grammar.y
@@ -101,7 +101,7 @@ fstring
 
 stmt
   : "let" IDENT optional_type_hint '=' expr ';'
-  | "assert" expr ',' expr ';'
+  | "assert" expr ':' expr ';'
   | "trace" expr ';'
   ;
 

--- a/grammar/tree-sitter-rcl/grammar.js
+++ b/grammar/tree-sitter-rcl/grammar.js
@@ -222,7 +222,10 @@ module.exports = grammar({
     stmt_assert: $ => seq(
       "assert",
       field("condition", $._expr),
-      ",",
+      // TODO: In a future version, we should accept only ':', for now we also
+      // accept comma for backwards compatibility. When changing this, be sure
+      // to also update `parser.rs`.
+      choice(":", ","),
       field("message", $._expr),
     ),
     stmt_trace: $ => seq(

--- a/grammar/tree-sitter-rcl/test/corpus/stmt.txt
+++ b/grammar/tree-sitter-rcl/test/corpus/stmt.txt
@@ -17,7 +17,9 @@ let x = y; x
 Assert
 ======
 
-assert p == q, r; s
+assert p == q: r;
+assert p == q, r;
+s
 
 ---
 
@@ -26,7 +28,11 @@ assert p == q, r; s
     (stmt_assert
       condition: (expr_binop (ident) (binop) (ident))
       message: (ident))
-    (ident)))
+    (expr_stmt
+      (stmt_assert
+        condition: (expr_binop (ident) (binop) (ident))
+        message: (ident))
+      (ident))))
 
 =====
 Trace

--- a/src/fmt_cst.rs
+++ b/src/fmt_cst.rs
@@ -288,18 +288,13 @@ impl<'a> Formatter<'a> {
             Stmt::Assert {
                 condition, message, ..
             } => {
-                concat! {
+                group! {
                     Doc::str("assert").with_markup(Markup::Keyword)
-                    group! {
-                        indent! {
-                            Doc::Sep
-                            self.expr(condition)
-                            ":"
-                            Doc::Sep
-                            self.expr(message)
-                            ";"
-                        }
-                    }
+                    " "
+                    self.expr(condition)
+                    ":"
+                    Doc::Sep
+                    indent! { self.expr(message) ";" }
                 }
             }
             Stmt::Trace { message, .. } => {

--- a/src/fmt_cst.rs
+++ b/src/fmt_cst.rs
@@ -294,7 +294,7 @@ impl<'a> Formatter<'a> {
                         indent! {
                             Doc::Sep
                             self.expr(condition)
-                            ","
+                            ":"
                             Doc::Sep
                             self.expr(message)
                             ";"

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -452,23 +452,29 @@ impl<'a> Parser<'a> {
         self.skip_non_code()?;
         let (condition_span, condition) = self.parse_expr()?;
 
-        // After the condition is a comma, but if the user wrote a semicolon,
+        // After the condition is a colon, but if the user wrote a semicolon,
         // then explain that the message is not optional (unlike in Python).
+        // For historical reasons, we also allow a comma instead of a colon:
+        // up to version 0.10.0, RCL used a comma like Python.
+        // TODO: Remove this compatibility, and make the comma an error. We can
+        // keep a friendly error to point Pythonistas in the right direction.
+        // TODO: Be sure to update the Tree-sitter grammar when changing this.
         self.skip_non_code()?;
         match self.peek() {
+            Token::Colon => self.consume(),
             Token::Comma => self.consume(),
             Token::Semicolon => {
                 return self
-                    .error("Expected ',' here between the assertion condition and message.")
+                    .error("Expected ':' here between the assertion condition and message.")
                     .with_help(
-                        "An assertion has the form 'assert <condition>, <message>;'. \
+                        "An assertion has the form 'assert <condition>: <message>;'. \
                         The message is not optional.",
                     )
                     .err();
             }
             _ => {
                 return self
-                    .error("Expected ',' here between the assertion condition and message.")
+                    .error("Expected ':' here between the assertion condition and message.")
                     .err()
             }
         };


### PR DESCRIPTION
The comma syntax is one I originally copied from Python, but while scrolling through the Jsonnet docs, they use a colon, and I find that to look more pleasant. I think the tall formatting is also more sensible with colon rather than a comma (it can work like `if`, rather than a function call).

This is not a breaking change: we can simply accept both `,` and `:`. The formatter will always output `:`, which from now on is the official style. At some point this behavior needs to be cleaned up; it could be done together with making the `:` after `else` non-optional, but for now there is no pressure.

 * [x] Ensure documentation is up to date
 * [x] Ensure changelog is up to date
 * [x] Ensure test coverage
 * [ ] Ensure fuzzers discover new code paths
 * [x] Ensure grammars and fuzz dictionary are up to date