### PR TITLE
Add a Visual Studio Code extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,8 +125,8 @@ target/release/rcl fmt examples/tags.rcl
 
 RCL is usable and useful, well-tested, and well-documented. It is still pre-1.0,
 though backwards-incompatible changes have been rare in the past years. Syntax
-highlighting is available for major editors like Vim, Emacs, Helix, and Zed.
-RCL is a community project without commercial support.
+highlighting is available for major editors like Vim, Emacs, Helix, VSCode, and
+Zed. RCL is a community project without commercial support.
 
 ## Support RCL
 

--- a/build.rcl
+++ b/build.rcl
@@ -17,11 +17,19 @@ let target_toml = contents => {
   contents = contents,
 };
 
+let target_json = contents => {
+  format = "json",
+  contents = contents,
+};
+
 {
   "Cargo.toml": target_toml(import "//Cargo.rcl"),
   "fuzz/Cargo.toml": target_toml(import "//fuzz/Cargo.rcl"),
   "grammar/tree-sitter-rcl/Cargo.toml": target_toml(
     import "//grammar/tree-sitter-rcl/Cargo.rcl",
+  ),
+  "grammar/vscode/package.json": target_json(
+    import "//grammar/vscode/package.rcl",
   ),
   "grammar/zed/extension.toml": target_toml(
     import "//grammar/zed/extension.rcl",

--- a/build.rcl
+++ b/build.rcl
@@ -29,10 +29,13 @@ let target_json = contents => {
     import "//grammar/tree-sitter-rcl/Cargo.rcl",
   ),
   "grammar/vscode/language-configuration.json": target_json(
-    import "//grammar/vscode/language-configuration.rcl"
+    import "//grammar/vscode/language-configuration.rcl",
   ),
   "grammar/vscode/package.json": target_json(
-    import "//grammar/vscode/package.rcl"
+    import "//grammar/vscode/package.rcl",
+  ),
+  "grammar/vscode/rcl.tmLanguage.json": target_json(
+    import "//grammar/vscode/rcl.tmLanguage.rcl",
   ),
   "grammar/zed/extension.toml": target_toml(
     import "//grammar/zed/extension.rcl",

--- a/build.rcl
+++ b/build.rcl
@@ -28,8 +28,11 @@ let target_json = contents => {
   "grammar/tree-sitter-rcl/Cargo.toml": target_toml(
     import "//grammar/tree-sitter-rcl/Cargo.rcl",
   ),
+  "grammar/vscode/language-configuration.json": target_json(
+    import "//grammar/vscode/language-configuration.rcl"
+  ),
   "grammar/vscode/package.json": target_json(
-    import "//grammar/vscode/package.rcl",
+    import "//grammar/vscode/package.rcl"
   ),
   "grammar/zed/extension.toml": target_toml(
     import "//grammar/zed/extension.rcl",

--- a/build.rcl
+++ b/build.rcl
@@ -31,6 +31,8 @@ let target_json = contents => {
   "grammar/vscode/language-configuration.json": target_json(
     import "//grammar/vscode/language-configuration.rcl",
   ),
+  // TODO: Maybe instead of checking these generated json files
+  // in to the repository, we can just generate them at package build time.
   "grammar/vscode/package.json": target_json(
     import "//grammar/vscode/package.rcl",
   ),

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -23,6 +23,9 @@ Unreleased.
    function calls.
  * Add the [`systemd` output format](output_formats.md#systemd) for generating
    systemd units from <abbr>RCL</abbr>.
+ * Add a [Visual Studio Code extension](syntax_highlighting.md#visual-studio-code),
+   which also brings syntax highlighting to
+   [JetBrains <abbr>IDE</abbr>s](syntax_highlighting.md#jetbrains).
 
 ## 0.13.0
 

--- a/docs/grammars.md
+++ b/docs/grammars.md
@@ -45,8 +45,9 @@ to use for highlighting, similar to scopes for Tree Sitter.
 ## Visual Studio Code
 
 The `vscode` directory contains the Visual Studio Code plugin including TextMate
-grammar. The TextMate documentation has [a section on scope naming
-conventions][tm-scopes]. Some helpful links:
+grammar. The json version of the grammar is generated with <abbr>RCL</abbr>. The
+TextMate documentation has [a section on scope naming conventions][tm-scopes].
+Some helpful links:
 
  * [TextMate language grammar documentation][tm-docs]
  * [Helpful _lessons learned_ blog post][tm-lessons]
@@ -56,6 +57,10 @@ conventions][tm-scopes]. Some helpful links:
 [tm-scopes]:        https://macromates.com/manual/en/language_grammars#naming_conventions
 [tm-lessons]:       https://www.apeth.com/nonblog/stories/textmatebundle.html
 [vscode-highlight]: https://code.visualstudio.com/api/language-extensions/syntax-highlight-guide
+
+The Nix flake includes a <abbr>VSIX</abbr> extension package. To build it:
+
+    nix build .#vscode-extension
 
 ## Zed
 

--- a/docs/grammars.md
+++ b/docs/grammars.md
@@ -45,7 +45,17 @@ to use for highlighting, similar to scopes for Tree Sitter.
 ## Visual Studio Code
 
 The `vscode` directory contains the Visual Studio Code plugin including TextMate
-grammar.
+grammar. The TextMate documentation has [a section on scope naming
+conventions][tm-scopes]. Some helpful links:
+
+ * [TextMate language grammar documentation][tm-docs]
+ * [Helpful _lessons learned_ blog post][tm-lessons]
+ * [VSCode syntax highlighting docs][vscode-highlight]
+
+[tm-docs]:          https://macromates.com/manual/en/language_grammars
+[tm-scopes]:        https://macromates.com/manual/en/language_grammars#naming_conventions
+[tm-lessons]:       https://www.apeth.com/nonblog/stories/textmatebundle.html
+[vscode-highlight]: https://code.visualstudio.com/api/language-extensions/syntax-highlight-guide
 
 ## Zed
 

--- a/docs/grammars.md
+++ b/docs/grammars.md
@@ -42,6 +42,11 @@ to use for highlighting, similar to scopes for Tree Sitter.
 
 [vim-groups]: https://vimhelp.org/syntax.txt.html#group-name
 
+## Visual Studio Code
+
+The `vscode` directory contains the Visual Studio Code plugin including TextMate
+grammar.
+
 ## Zed
 
 The `zed` directory contains the Zed plugin. This directory is the source of

--- a/docs/index.md
+++ b/docs/index.md
@@ -53,8 +53,8 @@ For an interactive demo in your browser, see <https://rcl-lang.org>.
 
 RCL is usable and useful, well-tested, and well-documented. It is still pre-1.0,
 though backwards-incompatible changes have been rare in the past years. Syntax
-highlighting is available for major editors like Vim, Emacs, Helix, and Zed.
-RCL is a community project without commercial support.
+highlighting is available for major editors like Vim, Emacs, Helix, VSCode, and
+Zed. RCL is a community project without commercial support.
 
 ## License
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -107,8 +107,11 @@ For releases that have impact on the grammars or extensions:
  * Update external repositories: `tools/update_repos.py`.
  * Push to GitHub and Codeberg.
  * Make a pull request to update [zed-industries/extensions][zed-ext].
+ * For VSCode: `nix build .#vscode-extension`, upload the <abbr>VSIX</abbr> file
+   to [the marketplace][vs-marketplace].
 
 [zed-ext]: https://github.com/zed-industries/extensions
+[vs-marketplace]: https://marketplace.visualstudio.com/manage/publishers/rcl-lang
 
 ### Arch User Repository
 

--- a/docs/syntax_highlighting.md
+++ b/docs/syntax_highlighting.md
@@ -91,6 +91,19 @@ The directory `grammar/rcl.vim` contains support for highlighting in Vim.
 You can symlink the contents into your `~/.vim`, or use a plugin manager like
 Pathogen and symlink the directory into `~/.vim/bundle`.
 
+## Visual Studio Code
+
+The [Visual Studio Code extension][vscode-ext] is available from the Visual
+Studio marketplace.
+
+If you want to install a development version of the extension, the extension
+is developed in the main repository. See [the section in the grammars
+chapter][grammars-vscode] for how to build it, then install the extension using
+_Extensions: Install from <abbr>VSIX</abbr>…_ from the command panel.
+
+[vscode-ext]: https://marketplace.visualstudio.com/items?itemName=rcl-lang.rcl
+[grammars-vscode]: grammars.md#visual-studio-code
+
 ## Zed
 
 The [Zed extension](https://github.com/rcl-lang/zed-rcl) is available from the

--- a/docs/syntax_highlighting.md
+++ b/docs/syntax_highlighting.md
@@ -34,6 +34,18 @@ your Helix configuation directory at `runtime/queries/rcl/highlights.scm`.
 
 [helix-lang]: https://docs.helix-editor.com/guides/adding_languages.html
 
+## JetBrains
+
+JetBrains <abbr>IDE</abbr>s can,
+through the integrated [TextMate plugin][jb-tm],
+use the [Visual Studio Code extension](#visual-studio-code).
+First clone the <abbr>RCL</abbr> repository. Then in the <abbr>IDE</abbr>, go to
+_Settings_ &gt; _Editor_ &gt; _TextMate Bundles_, click the `+` button, and
+select the `grammar/vscode` directory in the repository. That’s it, everything
+is configured automatically!
+
+[jb-tm]: https://www.jetbrains.com/help/idea/textmate.html
+
 ## Neovim
 
 Neovim can use [the Tree-sitter grammar](#tree-sitter) through the

--- a/flake.nix
+++ b/flake.nix
@@ -412,6 +412,29 @@
             RUSTFLAGS = "-C instrument-coverage -C link-dead-code -C debug-assertions";
           });
 
+          vscode-extension = pkgs.stdenv.mkDerivation {
+            pname = "rcl-vscode";
+            inherit version;
+            src = ./grammar/vscode;
+            nativeBuildInputs = [ pkgs.vsce ];
+            doCheck = false;
+            buildPhase =
+              ''
+              # We want only the json files, not the RCL sources. Also, the
+              # `vsce` tool complains if there is no LICENSE file, so copy it
+              # in.
+              rm *.rcl
+              cp ${./LICENSE} LICENSE
+
+              # TODO: The VSIX file is just a zip file of the directory, with
+              # two additional XML files in it. One of them may be kind of a
+              # pain to generate, but on the other hand, we could skip nodejs
+              # if we build the zip file ourselves.
+              mkdir -p $out
+              vsce package --no-dependencies --out $out/rcl-${version}.vsix
+              '';
+          };
+
         in
           rec {
             devShells.default = pkgs.mkShell {
@@ -545,7 +568,7 @@
             };
 
             packages = {
-              inherit fuzzers-coverage rcl pyrcl pyrcl-wheel treeSitterRcl website;
+              inherit fuzzers-coverage rcl pyrcl pyrcl-wheel treeSitterRcl vscode-extension website;
 
               default = rcl;
               binaries = rcl-binaries;

--- a/flake.nix
+++ b/flake.nix
@@ -158,7 +158,7 @@
 
           pythonSources = pkgs.lib.sourceFilesBySuffices ./. [ ".py" ".pyi" ];
 
-          rclTomlSources = pkgs.lib.sourceFilesBySuffices ./. [ ".rcl" ".toml" ];
+          rclGeneratedSources = pkgs.lib.sourceFilesBySuffices ./. [ ".rcl" ".toml" ".json" ];
 
           goldenSources = ./golden;
 
@@ -503,14 +503,14 @@
                 "check-fmt-rcl"
                 { buildInputs = [ debugBuild ]; }
                 ''
-                rcl format --check ${rclTomlSources}/**.rcl | tee $out
+                rcl format --check ${rclGeneratedSources}/**.rcl | tee $out
                 '';
 
               buildRcl = pkgs.runCommand
                 "check-rcl-build"
                 { buildInputs = [ debugBuild ]; }
                 ''
-                rcl build --check --directory ${rclTomlSources} | tee $out
+                rcl build --check --directory ${rclGeneratedSources} | tee $out
                 '';
 
               # Build documentation with warnings denied, so the check fails if
@@ -561,7 +561,7 @@
                 RCL_BIN=${coverageBuild}/bin/rcl python3 ${goldenSources}/run.py
 
                 # Also run `rcl build` to make sure we cover that part of the application.
-                ${coverageBuild}/bin/rcl build --check --directory ${rclTomlSources}
+                ${coverageBuild}/bin/rcl build --check --directory ${rclGeneratedSources}
 
                 # Copy in the .profraw files from the tests.
                 cp ${coverageBuild}/prof/*.profraw .

--- a/flake.nix
+++ b/flake.nix
@@ -412,8 +412,12 @@
             RUSTFLAGS = "-C instrument-coverage -C link-dead-code -C debug-assertions";
           });
 
+          iconPng = pkgs.runCommand "rcl-icon.png"
+            { buildInputs = [ pkgs.resvg ]; }
+            "resvg --width 256 --height 256 ${./website/favicon.svg} $out";
+
           vscode-extension = pkgs.stdenv.mkDerivation {
-            pname = "rcl-vscode";
+            name = "rcl-vscode";
             inherit version;
             src = ./grammar/vscode;
             nativeBuildInputs = [ pkgs.vsce ];
@@ -425,6 +429,7 @@
               # in.
               rm *.rcl
               cp ${./LICENSE} LICENSE
+              cp ${iconPng} icon.png;
 
               # TODO: The VSIX file is just a zip file of the directory, with
               # two additional XML files in it. One of them may be kind of a
@@ -449,6 +454,7 @@
                 pkgs.esbuild
                 pkgs.grcov
                 pkgs.nodejs  # Required for tree-sitter.
+                pkgs.resvg
                 pkgs.rustup
                 pkgs.tree-sitter
                 pkgs.wasm-bindgen-cli

--- a/grammar/vscode/CHANGELOG.md
+++ b/grammar/vscode/CHANGELOG.md
@@ -1,0 +1,2 @@
+Changes to the VSCode extension are listed as part of
+[the regular RCL changelog](https://docs.ruuda.nl/rcl/changelog/).

--- a/grammar/vscode/README.md
+++ b/grammar/vscode/README.md
@@ -1,0 +1,26 @@
+# The RCL Configuration Language
+
+This extension provides support for the [RCL configuration language][rcl-lang].
+The RCL configuration language is a domain-specific language that extends json
+into a simple, gradually typed, functional language that resembles Python and
+Nix. It reduces configuration boilerplate by enabling abstraction and reuse.
+
+ * [Website and online playground][rcl-lang]
+ * [General documentation][docs]
+
+[rcl-lang]: https://rcl-lang.org/
+[docs]: https://docs.ruuda.nl/rcl/
+
+# About
+
+This extension is official. It is developed upstream as part of the main
+repository, in the `grammar/vscode` directory. It is available from the
+following mirrors:
+
+ * <https://codeberg.org/ruuda/rcl>
+ * <https://github.com/ruuda/rcl>
+
+For hacking on the extension itself, see the [Grammars][docs-grammars] chapter
+of the documentation.
+
+[docs-grammars]: https://docs.ruuda.nl/rcl/grammars/#visual-studio-code

--- a/grammar/vscode/language-configuration.json
+++ b/grammar/vscode/language-configuration.json
@@ -1,0 +1,12 @@
+{
+  "autoCloseBefore": ":.,",
+  "autoClosingPairs": [
+    {"close": "}", "open": "{"},
+    {"close": "]", "open": "["},
+    {"close": ")", "open": "("},
+    {"close": "\"", "notIn": ["string"], "open": "\""}
+  ],
+  "brackets": [["{", "}"], ["[", "]"], ["(", ")"]],
+  "comments": {"lineComment": "//"},
+  "surroundingPairs": [["\"", "\""], ["(", ")"], ["[", "]"], ["{", "}"]]
+}

--- a/grammar/vscode/language-configuration.json
+++ b/grammar/vscode/language-configuration.json
@@ -1,12 +1,20 @@
 {
-  "autoCloseBefore": ":.,;",
+  "autoCloseBefore": ":.,;}])",
   "autoClosingPairs": [
     {"close": "}", "open": "{"},
     {"close": "]", "open": "["},
     {"close": ")", "open": "("},
+    {"close": "\"\"\"", "notIn": ["string"], "open": "f\"\"\""},
+    {"close": "\"", "notIn": ["string"], "open": "f\""},
+    {"close": "\"\"\"", "notIn": ["string"], "open": "\"\"\""},
     {"close": "\"", "notIn": ["string"], "open": "\""}
   ],
   "brackets": [["{", "}"], ["[", "]"], ["(", ")"]],
   "comments": {"lineComment": "//"},
-  "surroundingPairs": [["\"", "\""], ["(", ")"], ["[", "]"], ["{", "}"]]
+  "indentationRules": {
+    "decreaseIndentPattern": "^\\s*[\\]\\}\\)][,;]?$",
+    "increaseIndentPattern": "^.*(\\[[^\\]]*|\\{[^\\}]*|\\([^\\)]*)$"
+  },
+  "onEnterRules": [],
+  "surroundingPairs": [["{", "}"], ["[", "]"], ["(", ")"], ["\"", "\""]]
 }

--- a/grammar/vscode/language-configuration.json
+++ b/grammar/vscode/language-configuration.json
@@ -1,5 +1,5 @@
 {
-  "autoCloseBefore": ":.,",
+  "autoCloseBefore": ":.,;",
   "autoClosingPairs": [
     {"close": "}", "open": "{"},
     {"close": "]", "open": "["},

--- a/grammar/vscode/language-configuration.rcl
+++ b/grammar/vscode/language-configuration.rcl
@@ -1,0 +1,29 @@
+// RCL -- A reasonable configuration language.
+// Copyright 2025 Ruud van Asseldonk
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// A copy of the License has been included in the root of the repository.
+
+let brackets = [
+  ["{", "}"],
+  ["[", "]"],
+  ["(", ")"],
+];
+
+{
+  comments = { lineComment = "//" },
+  brackets = brackets,
+  autoClosingPairs = [
+    for b in brackets: { open = b[0], close = b[1] },
+    { open = "\"", close = "\"", notIn = ["string"] },
+  ],
+  autoCloseBefore = ":.,",
+  surroundingPairs = {
+    for b in brackets: b,
+    ["\"", "\""],
+  },
+  // TODO: Add `folding`?
+  // TODO: Add `wordPattern`?
+  // TODO: Add `indentationRules`? I can't make sense of the example regex.
+}

--- a/grammar/vscode/language-configuration.rcl
+++ b/grammar/vscode/language-configuration.rcl
@@ -11,19 +11,55 @@ let brackets = [
   ["(", ")"],
 ];
 
+let quotes = [
+  for f in ["f", ""]:
+  for q in ["\"\"\"", "\""]:
+  [f"{f}{q}", q],
+];
+
 {
   comments = { lineComment = "//" },
   brackets = brackets,
   autoClosingPairs = [
     for b in brackets: { open = b[0], close = b[1] },
-    { open = "\"", close = "\"", notIn = ["string"] },
+    for q in quotes: { open = q[0], close = q[1], notIn = ["string"] },
   ],
-  autoCloseBefore = ":.,;",
-  surroundingPairs = {
-    for b in brackets: b,
+  autoCloseBefore = ":.,;}])",
+
+  // If you insert the opener before selected text, it adds the closer at the
+  // end. I think it only works for single-character surrounders?
+  // <https://code.visualstudio.com/api/language-extensions/language-configuration-guide#autosurrounding>
+  surroundingPairs = [
+    ..brackets,
     ["\"", "\""],
+  ],
+
+  // VSCode itself does not really need the indentation rules, the defaults work,
+  // but when imported by JetBrains' TextMate plugin, these rules are useful.
+  indentationRules = {
+    // An opening bracket, not followed by a closing bracket of the same kind.
+    // Simplified from the default in the VSCode docs at
+    // <https://code.visualstudio.com/api/language-extensions/language-configuration-guide#indentation-rules>.
+    // Clearer docs are at <https://macromates.com/manual/en/appendix>.
+    // We don't handle comments or strings, that gets complex quickly, an
+    // editor would be better off using the Tree-sitter grammar ...
+    increaseIndentPattern = "^.*(\\[[^\\]]*|\\{[^\\}]*|\\([^\\)]*)$",
+
+    // When we type and the line matches this pattern -- for example when we
+    // type a closing paren, the entire line gets dedented. I suppose that's
+    // useful when the closing brace did not autocomplete, and you type it
+    // yourself, but VSCode already handles that anyway. Still, we put this
+    // here to satisfy the schema. Match only if there is nothing else on the
+    // line, you dont want a dedent when you type the `)` after `f(` on the
+    // same line.
+    decreaseIndentPattern = "^\\s*[\\]\\}\\)][,;]?$",
   },
-  // TODO: Add `folding`?
-  // TODO: Add `wordPattern`?
-  // TODO: Add `indentationRules`? I can't make sense of the example regex.
+
+  // Putting the closing bracket on the next line when you press enter inside
+  // auto-completed brackets should be fixable with onEnterRules indentOutdent,
+  // but JetBrains does not respect it, and VSCode works fine without a specific
+  // declaration, so skip it.
+  onEnterRules = [],
+
+  // We might set `wordPattern`, but VSCode's default is good enough for now.
 }

--- a/grammar/vscode/language-configuration.rcl
+++ b/grammar/vscode/language-configuration.rcl
@@ -14,7 +14,7 @@ let brackets = [
 let quotes = [
   for f in ["f", ""]:
   for q in ["\"\"\"", "\""]:
-  [f"{f}{q}", q],
+  [f"{f}{q}", q]
 ];
 
 {

--- a/grammar/vscode/language-configuration.rcl
+++ b/grammar/vscode/language-configuration.rcl
@@ -18,7 +18,7 @@ let brackets = [
     for b in brackets: { open = b[0], close = b[1] },
     { open = "\"", close = "\"", notIn = ["string"] },
   ],
-  autoCloseBefore = ":.,",
+  autoCloseBefore = ":.,;",
   surroundingPairs = {
     for b in brackets: b,
     ["\"", "\""],

--- a/grammar/vscode/package.json
+++ b/grammar/vscode/package.json
@@ -9,7 +9,14 @@
         "scopeName": "text.rcl"
       }
     ],
-    "languages": [{"aliases": ["RCL"], "extensions": [".rcl"], "id": "rcl"}]
+    "languages": [
+      {
+        "aliases": ["RCL"],
+        "configuration": "./language-configuration.json",
+        "extensions": [".rcl"],
+        "id": "rcl"
+      }
+    ]
   },
   "description": "Support for the RCL configuration language.",
   "displayName": "RCL",

--- a/grammar/vscode/package.json
+++ b/grammar/vscode/package.json
@@ -6,7 +6,7 @@
       {
         "language": "rcl",
         "path": "./rcl.tmLanguage.json",
-        "scopeName": "text.rcl"
+        "scopeName": "source.rcl"
       }
     ],
     "languages": [

--- a/grammar/vscode/package.json
+++ b/grammar/vscode/package.json
@@ -1,0 +1,23 @@
+{
+  "author": {"name": "Ruud van Asseldonk"},
+  "categories": ["Programming Languages"],
+  "contributes": {
+    "grammars": [
+      {
+        "language": "rcl",
+        "path": "./rcl.tmLanguage.json",
+        "scopeName": "text.rcl"
+      }
+    ],
+    "languages": [{"aliases": ["RCL"], "extensions": [".rcl"], "id": "rcl"}]
+  },
+  "description": "Support for the RCL configuration language.",
+  "displayName": "RCL",
+  "engines": {"vscode": "^1.100.0"},
+  "homepage": "https://rcl-lang.org",
+  "license": "Apache-2.0",
+  "name": "rcl",
+  "publisher": "TODO",
+  "repository": {"type": "git", "url": "https://github.com/ruuda/rcl.git"},
+  "version": "0.13.0"
+}

--- a/grammar/vscode/package.json
+++ b/grammar/vscode/package.json
@@ -2,6 +2,9 @@
   "author": {"name": "Ruud van Asseldonk"},
   "categories": ["Programming Languages"],
   "contributes": {
+    "configurationDefaults": {
+      "[rcl]": {"editor.insertSpaces": true, "editor.tabSize": 2}
+    },
     "grammars": [
       {
         "language": "rcl",
@@ -24,7 +27,8 @@
   "homepage": "https://rcl-lang.org",
   "license": "Apache-2.0",
   "name": "rcl",
-  "publisher": "TODO",
+  "preview": true,
+  "publisher": "rcl-lang",
   "repository": {"type": "git", "url": "https://github.com/ruuda/rcl.git"},
   "version": "0.13.0"
 }

--- a/grammar/vscode/package.json
+++ b/grammar/vscode/package.json
@@ -24,6 +24,7 @@
   "description": "Support for the RCL configuration language.",
   "displayName": "RCL",
   "engines": {"vscode": "^1.100.0"},
+  "galleryBanner": {"color": "#000f29", "theme": "dark"},
   "homepage": "https://rcl-lang.org",
   "icon": "icon.png",
   "license": "Apache-2.0",

--- a/grammar/vscode/package.json
+++ b/grammar/vscode/package.json
@@ -25,10 +25,11 @@
   "displayName": "RCL",
   "engines": {"vscode": "^1.100.0"},
   "homepage": "https://rcl-lang.org",
+  "icon": "icon.png",
   "license": "Apache-2.0",
   "name": "rcl",
   "preview": true,
   "publisher": "rcl-lang",
   "repository": {"type": "git", "url": "https://github.com/ruuda/rcl.git"},
-  "version": "0.13.0"
+  "version": "0.13.1"
 }

--- a/grammar/vscode/package.json
+++ b/grammar/vscode/package.json
@@ -30,9 +30,9 @@
   "keywords": ["rcl", "json", "yaml", "toml", "configuration", "devops"],
   "license": "Apache-2.0",
   "name": "rcl",
-  "preview": true,
+  "preview": false,
   "pricing": "Free",
   "publisher": "rcl-lang",
   "repository": {"type": "git", "url": "https://github.com/ruuda/rcl.git"},
-  "version": "0.13.1"
+  "version": "0.13.0"
 }

--- a/grammar/vscode/package.json
+++ b/grammar/vscode/package.json
@@ -27,9 +27,11 @@
   "galleryBanner": {"color": "#000f29", "theme": "dark"},
   "homepage": "https://rcl-lang.org",
   "icon": "icon.png",
+  "keywords": ["rcl", "json", "yaml", "toml", "configuration", "devops"],
   "license": "Apache-2.0",
   "name": "rcl",
   "preview": true,
+  "pricing": "Free",
   "publisher": "rcl-lang",
   "repository": {"type": "git", "url": "https://github.com/ruuda/rcl.git"},
   "version": "0.13.1"

--- a/grammar/vscode/package.rcl
+++ b/grammar/vscode/package.rcl
@@ -21,8 +21,7 @@ let root = import "//Cargo.rcl";
         id = "rcl",
         aliases = ["RCL"],
         extensions = [".rcl"],
-        // TODO: Is a language-configuration.json mandatory?
-        // We can add one later, let's focus on the grammar first.
+        configuration = "./language-configuration.json",
       },
     ],
     grammars = [

--- a/grammar/vscode/package.rcl
+++ b/grammar/vscode/package.rcl
@@ -1,0 +1,36 @@
+let root = import "//Cargo.rcl";
+
+{
+  name = "rcl",
+  displayName = "RCL",
+  description = "Support for the RCL configuration language.",
+  version = root.package.version,
+  license = root.package.license,
+  author = { name = "Ruud van Asseldonk" },
+  publisher = "TODO",
+
+  engines = { vscode = "^1.100.0" },
+  categories = ["Programming Languages"],
+
+  repository = { type = "git", url = "https://github.com/ruuda/rcl.git" },
+  homepage = "https://rcl-lang.org",
+
+  contributes = {
+    languages = [
+      {
+        id = "rcl",
+        aliases = ["RCL"],
+        extensions = [".rcl"],
+        // TODO: Is a language-configuration.json mandatory?
+        // We can add one later, let's focus on the grammar first.
+      },
+    ],
+    grammars = [
+      {
+        language = "rcl",
+        scopeName = "text.rcl",
+        path = "./rcl.tmLanguage.json",
+      },
+    ],
+  },
+}

--- a/grammar/vscode/package.rcl
+++ b/grammar/vscode/package.rcl
@@ -27,7 +27,7 @@ let root = import "//Cargo.rcl";
     grammars = [
       {
         language = "rcl",
-        scopeName = "text.rcl",
+        scopeName = "source.rcl",
         path = "./rcl.tmLanguage.json",
       },
     ],

--- a/grammar/vscode/package.rcl
+++ b/grammar/vscode/package.rcl
@@ -4,10 +4,12 @@ let root = import "//Cargo.rcl";
   name = "rcl",
   displayName = "RCL",
   description = "Support for the RCL configuration language.",
+  // TODO: Remove the preview designation once the extension is ready.
+  preview = true,
   version = root.package.version,
   license = root.package.license,
   author = { name = "Ruud van Asseldonk" },
-  publisher = "TODO",
+  publisher = "rcl-lang",
 
   engines = { vscode = "^1.100.0" },
   categories = ["Programming Languages"],
@@ -31,5 +33,11 @@ let root = import "//Cargo.rcl";
         path = "./rcl.tmLanguage.json",
       },
     ],
+    configurationDefaults = {
+      "[rcl]": {
+        "editor.tabSize": 2,
+        "editor.insertSpaces": true,
+      },
+    },
   },
 }

--- a/grammar/vscode/package.rcl
+++ b/grammar/vscode/package.rcl
@@ -17,6 +17,7 @@ let root = import "//Cargo.rcl";
   // The png is rendered from the svg favicon automatically,
   // see `iconPng` in `flake.nix`.
   icon = "icon.png",
+  galleryBanner = { color = "#000f29", theme = "dark" },
 
   engines = { vscode = "^1.100.0" },
   categories = ["Programming Languages"],

--- a/grammar/vscode/package.rcl
+++ b/grammar/vscode/package.rcl
@@ -9,18 +9,21 @@ let root = import "//Cargo.rcl";
   preview = true,
   version = root.package.version,
   version = "0.13.1",
+  engines = { vscode = "^1.100.0" },
 
-  license = root.package.license,
   author = { name = "Ruud van Asseldonk" },
   publisher = "rcl-lang",
+  license = root.package.license,
+  pricing = "Free",
 
   // The png is rendered from the svg favicon automatically,
   // see `iconPng` in `flake.nix`.
   icon = "icon.png",
   galleryBanner = { color = "#000f29", theme = "dark" },
 
-  engines = { vscode = "^1.100.0" },
+  // TODO: Extend with "Linters" and "Formatters" once we have a language server.
   categories = ["Programming Languages"],
+  keywords = ["rcl", "json", "yaml", "toml", "configuration", "devops"],
 
   repository = { type = "git", url = "https://github.com/ruuda/rcl.git" },
   homepage = "https://rcl-lang.org",

--- a/grammar/vscode/package.rcl
+++ b/grammar/vscode/package.rcl
@@ -4,12 +4,19 @@ let root = import "//Cargo.rcl";
   name = "rcl",
   displayName = "RCL",
   description = "Support for the RCL configuration language.",
-  // TODO: Remove the preview designation once the extension is ready.
+  // TODO: Remove the preview designation once the extension is ready,
+  // make the version match upstream again.
   preview = true,
   version = root.package.version,
+  version = "0.13.1",
+
   license = root.package.license,
   author = { name = "Ruud van Asseldonk" },
   publisher = "rcl-lang",
+
+  // The png is rendered from the svg favicon automatically,
+  // see `iconPng` in `flake.nix`.
+  icon = "icon.png",
 
   engines = { vscode = "^1.100.0" },
   categories = ["Programming Languages"],

--- a/grammar/vscode/package.rcl
+++ b/grammar/vscode/package.rcl
@@ -4,11 +4,8 @@ let root = import "//Cargo.rcl";
   name = "rcl",
   displayName = "RCL",
   description = "Support for the RCL configuration language.",
-  // TODO: Remove the preview designation once the extension is ready,
-  // make the version match upstream again.
-  preview = true,
+  preview = false,
   version = root.package.version,
-  version = "0.13.1",
   engines = { vscode = "^1.100.0" },
 
   author = { name = "Ruud van Asseldonk" },

--- a/grammar/vscode/rcl.tmLanguage.json
+++ b/grammar/vscode/rcl.tmLanguage.json
@@ -1,0 +1,22 @@
+{
+  "patterns": [{"include": "#expression"}],
+  "repository": {
+    "array": {
+      "begin": "\\[",
+      "beginCaptures": {"0": {"name": "punctuation.definition.array.begin.rcl"}},
+      "end": "\\]",
+      "endCaptures": {"0": {"name": "punctuation.definition.array.end.rcl"}},
+      "name": "meta.structure.array.json",
+      "patterns": [
+        {"include": "#value"},
+        {"match": ",", "name": "punctuation.separator.array.rcl"}
+      ]
+    },
+    "constant": {
+      "match": "\\b(?:true|false|null)\\b",
+      "name": "constant.language.rcl"
+    },
+    "value": {"patterns": [{"include": "#array"}, {"include": "#constant"}]}
+  },
+  "scopeName": "source.rcl"
+}

--- a/grammar/vscode/rcl.tmLanguage.json
+++ b/grammar/vscode/rcl.tmLanguage.json
@@ -82,7 +82,7 @@
       "patterns": [{"include": "#expr"}]
     },
     "seq_kv": {
-      "captures": {"1": {"name": "support.type.property-name.rcl"}},
+      "captures": {"1": {"name": "support.type.property-name.json.rcl"}},
       "match": "\\b([a-zA-Z_][a-zA-Z0-9_-]*)\\s+="
     },
     "stmt": {
@@ -108,7 +108,10 @@
               "end": "=",
               "name": "meta.structure.annotation.rcl",
               "patterns": [
-                {"match": "[a-zA-Z_][a-zA-Z0-9_-]*", "name": "storage.type.rcl"}
+                {
+                  "match": "[a-zA-Z_][a-zA-Z0-9_-]*",
+                  "name": "entity.name.type.rcl"
+                }
               ]
             },
             {

--- a/grammar/vscode/rcl.tmLanguage.json
+++ b/grammar/vscode/rcl.tmLanguage.json
@@ -40,7 +40,7 @@
         {"include": "#term_string"},
         {"include": "#term_number"},
         {"include": "#term_constant"},
-        {"match": "[a-zA-Z_][a-zA-Z0-9_]*", "name": "meta.structure.ident.rcl"}
+        {"match": "[a-zA-Z_][a-zA-Z0-9_-]*", "name": "meta.structure.ident.rcl"}
       ]
     },
     "expr_unop": {"match": "\\bnot\\b", "name": "keyword.operator.unop.rcl"},
@@ -65,7 +65,7 @@
           "end": "\\bin\\b",
           "endCaptures": {"0": {"name": "keyword.control.in.rcl"}},
           "patterns": [
-            {"match": "[a-zA-Z_][a-zA-Z0-9_]*", "name": "meta.declaration.rcl"}
+            {"match": "[a-zA-Z_][a-zA-Z0-9_-]*", "name": "meta.declaration.rcl"}
           ]
         },
         {
@@ -83,7 +83,7 @@
     },
     "seq_kv": {
       "captures": {"1": {"name": "support.type.property-name.rcl"}},
-      "match": "\\b([a-zA-Z_][a-zA-Z0-9_]*)\\s+="
+      "match": "\\b([a-zA-Z_][a-zA-Z0-9_-]*)\\s+="
     },
     "stmt": {
       "patterns": [
@@ -98,7 +98,7 @@
               "end": "[:=]",
               "patterns": [
                 {
-                  "match": "[a-zA-Z_][a-zA-Z0-9_]*",
+                  "match": "[a-zA-Z_][a-zA-Z0-9_-]*",
                   "name": "meta.declaration.rcl"
                 }
               ]
@@ -108,7 +108,7 @@
               "end": "=",
               "name": "meta.structure.annotation.rcl",
               "patterns": [
-                {"match": "[a-zA-Z_][a-zA-Z0-9_]*", "name": "storage.type.rcl"}
+                {"match": "[a-zA-Z_][a-zA-Z0-9_-]*", "name": "storage.type.rcl"}
               ]
             },
             {

--- a/grammar/vscode/rcl.tmLanguage.json
+++ b/grammar/vscode/rcl.tmLanguage.json
@@ -13,8 +13,15 @@
         {"include": "#term_bracket"},
         {"include": "#term_brace"},
         {"include": "#term_parens"},
-        {"include": "#constant"}
+        {"include": "#constant"},
+        {"include": "#term_string"}
       ]
+    },
+    "string_hole": {
+      "begin": "\\{",
+      "end": "\\}",
+      "name": "interpolate.rcl",
+      "patterns": [{"include": "#expr"}]
     },
     "term_brace": {
       "begin": "\\{",
@@ -57,6 +64,45 @@
       },
       "name": "meta.structure.term_parens.rcl",
       "patterns": [{"include": "#expr"}]
+    },
+    "term_string": {
+      "name": "string.quoted.rcl",
+      "patterns": [
+        {
+          "begin": "\"",
+          "end": "\"",
+          "name": "string.quoted.double.rcl",
+          "patterns": [
+            {"match": "\\.", "name": "constant.character.escape.rcl"}
+          ]
+        },
+        {
+          "begin": "\"\"\"",
+          "end": "\"\"\"",
+          "name": "string.quoted.triple.rcl",
+          "patterns": [
+            {"match": "\\.", "name": "constant.character.escape.rcl"}
+          ]
+        },
+        {
+          "begin": "f\"",
+          "end": "\"",
+          "name": "string.quoted.double.rcl",
+          "patterns": [
+            {"match": "\\.", "name": "constant.character.escape.rcl"},
+            {"include": "#string_hole"}
+          ]
+        },
+        {
+          "begin": "f\"\"\"",
+          "end": "\"\"\"",
+          "name": "string.quoted.triple.rcl",
+          "patterns": [
+            {"match": "\\.", "name": "constant.character.escape.rcl"},
+            {"include": "#string_hole"}
+          ]
+        }
+      ]
     }
   },
   "scopeName": "source.rcl"

--- a/grammar/vscode/rcl.tmLanguage.json
+++ b/grammar/vscode/rcl.tmLanguage.json
@@ -6,7 +6,7 @@
       "match": "\\b(?:true|false|null)\\b",
       "name": "constant.language.rcl"
     },
-    "expr": {"patterns": [{"include": "#expr_op"}]},
+    "expr": {"patterns": [{"include": "#stmt"}, {"include": "#expr_op"}]},
     "expr_not_op": {"patterns": [{"include": "#expr_term"}]},
     "expr_op": {"patterns": [{"include": "#expr_not_op"}]},
     "expr_term": {
@@ -16,6 +16,34 @@
         {"include": "#term_parens"},
         {"include": "#constant"},
         {"include": "#term_string"}
+      ]
+    },
+    "stmt": {
+      "patterns": [
+        {
+          "begin": "\\b(let)\\s+([^=;]+)\\s+=",
+          "beginCaptures": {
+            "1": {"name": "keyword.other.let.rcl"},
+            "2": {"name": "variable.rcl"}
+          },
+          "end": ";",
+          "name": "meta.structure.let.rcl",
+          "patterns": [{"include": "#expr"}]
+        },
+        {
+          "begin": "\\bassert\\b",
+          "beginCaptures": {"0": {"name": "keyword.control.assert.rcl"}},
+          "end": ";",
+          "name": "meta.structure.assert.rcl",
+          "patterns": [{"include": "#expr"}]
+        },
+        {
+          "begin": "\\btrace\\b",
+          "beginCaptures": {"0": {"name": "keyword.control.trace.rcl"}},
+          "end": ";",
+          "name": "meta.structure.trace.rcl",
+          "patterns": [{"include": "#expr"}]
+        }
       ]
     },
     "string_hole": {

--- a/grammar/vscode/rcl.tmLanguage.json
+++ b/grammar/vscode/rcl.tmLanguage.json
@@ -39,7 +39,7 @@
         {"include": "#term_string"},
         {"include": "#term_number"},
         {"include": "#term_constant"},
-        {"match": "[a-zA-Z_][a-zA-Z0-9_-]*", "name": "meta.structure.ident.rcl"}
+        {"match": "[a-zA-Z_][a-zA-Z0-9_]*", "name": "meta.structure.ident.rcl"}
       ]
     },
     "expr_unop": {"match": "\\bnot\\b", "name": "keyword.operator.unop.rcl"},
@@ -48,14 +48,18 @@
         {
           "begin": "\\blet\\b",
           "beginCaptures": {"0": {"name": "keyword.other.let.rcl"}},
-          "end": ";",
+          "end": "=",
           "name": "meta.structure.let.rcl",
           "patterns": [
             {
-              "captures": {"1": {"name": "variable.let.rcl"}},
-              "match": "\\s+([a-zA-Z_][a-zA-Z0-9_-]*)\\s*="
+              "begin": ":",
+              "end": "(?=[=])",
+              "name": "meta.structure.annotation.rcl",
+              "patterns": [
+                {"match": "[a-zA-Z_][a-zA-Z0-9_]*", "name": "storage.type.rcl"}
+              ]
             },
-            {"include": "#expr"}
+            {"match": "[a-zA-Z_][a-zA-Z0-9_]*", "name": "variable.let.rcl"}
           ]
         },
         {

--- a/grammar/vscode/rcl.tmLanguage.json
+++ b/grammar/vscode/rcl.tmLanguage.json
@@ -1,11 +1,7 @@
 {
   "patterns": [{"include": "#expr"}],
   "repository": {
-    "comment": {
-      "begin": "//",
-      "end": "\n",
-      "name": "comment.line.double-slash.rcl"
-    },
+    "comment": {"match": "//.*$", "name": "comment.line.double-slash.rcl"},
     "constant": {
       "match": "\\b(?:true|false|null)\\b",
       "name": "constant.language.rcl"
@@ -78,7 +74,15 @@
           "end": "\"",
           "name": "string.quoted.double.rcl",
           "patterns": [
-            {"match": "\\.", "name": "constant.character.escape.rcl"}
+            {
+              "match": "\\\\u\\{[0-9a-fA-F_]+\\}",
+              "name": "constant.character.escape.unibrace.rcl"
+            },
+            {
+              "match": "\\\\u[0-9a-fA-F_]{4}",
+              "name": "constant.character.escape.rcl"
+            },
+            {"match": "\\\\.", "name": "constant.character.escape.single.rcl"}
           ]
         },
         {
@@ -86,7 +90,15 @@
           "end": "\"\"\"",
           "name": "string.quoted.triple.rcl",
           "patterns": [
-            {"match": "\\.", "name": "constant.character.escape.rcl"}
+            {
+              "match": "\\\\u\\{[0-9a-fA-F_]+\\}",
+              "name": "constant.character.escape.unibrace.rcl"
+            },
+            {
+              "match": "\\\\u[0-9a-fA-F_]{4}",
+              "name": "constant.character.escape.rcl"
+            },
+            {"match": "\\\\.", "name": "constant.character.escape.single.rcl"}
           ]
         },
         {
@@ -94,7 +106,15 @@
           "end": "\"",
           "name": "string.quoted.double.rcl",
           "patterns": [
-            {"match": "\\.", "name": "constant.character.escape.rcl"},
+            {
+              "match": "\\\\u\\{[0-9a-fA-F_]+\\}",
+              "name": "constant.character.escape.unibrace.rcl"
+            },
+            {
+              "match": "\\\\u[0-9a-fA-F_]{4}",
+              "name": "constant.character.escape.rcl"
+            },
+            {"match": "\\\\.", "name": "constant.character.escape.single.rcl"},
             {"include": "#string_hole"}
           ]
         },
@@ -103,7 +123,15 @@
           "end": "\"\"\"",
           "name": "string.quoted.triple.rcl",
           "patterns": [
-            {"match": "\\.", "name": "constant.character.escape.rcl"},
+            {
+              "match": "\\\\u\\{[0-9a-fA-F_]+\\}",
+              "name": "constant.character.escape.unibrace.rcl"
+            },
+            {
+              "match": "\\\\u[0-9a-fA-F_]{4}",
+              "name": "constant.character.escape.rcl"
+            },
+            {"match": "\\\\.", "name": "constant.character.escape.single.rcl"},
             {"include": "#string_hole"}
           ]
         }

--- a/grammar/vscode/rcl.tmLanguage.json
+++ b/grammar/vscode/rcl.tmLanguage.json
@@ -1,11 +1,14 @@
 {
-  "patterns": [{"include": "#expression"}],
+  "patterns": [{"include": "#expr"}],
   "repository": {
     "constant": {
       "match": "\\b(?:true|false|null)\\b",
       "name": "constant.language.rcl"
     },
-    "expression": {
+    "expr": {"patterns": [{"include": "#expr_op"}]},
+    "expr_not_op": {"patterns": [{"include": "#expr_term"}]},
+    "expr_op": {"patterns": [{"include": "#expr_not_op"}]},
+    "expr_term": {
       "patterns": [
         {"include": "#term_bracket"},
         {"include": "#term_brace"},
@@ -24,7 +27,7 @@
       },
       "name": "meta.structure.term_brace.rcl",
       "patterns": [
-        {"include": "#expression"},
+        {"include": "#expr"},
         {"match": ",", "name": "punctuation.separator.term_brace.rcl"}
       ]
     },
@@ -39,7 +42,7 @@
       },
       "name": "meta.structure.term_bracket.rcl",
       "patterns": [
-        {"include": "#expression"},
+        {"include": "#expr"},
         {"match": ",", "name": "punctuation.separator.term_bracket.rcl"}
       ]
     },
@@ -53,7 +56,7 @@
         "0": {"name": "punctuation.definition.term_parens.end.rcl"}
       },
       "name": "meta.structure.term_parens.rcl",
-      "patterns": [{"include": "#expression"}]
+      "patterns": [{"include": "#expr"}]
     }
   },
   "scopeName": "source.rcl"

--- a/grammar/vscode/rcl.tmLanguage.json
+++ b/grammar/vscode/rcl.tmLanguage.json
@@ -2,20 +2,18 @@
   "patterns": [{"include": "#expr"}, {"include": "#comment"}],
   "repository": {
     "comment": {"match": "//.*$", "name": "comment.line.double-slash.rcl"},
-    "constant": {
-      "match": "\\b(?:true|false|null)\\b",
-      "name": "constant.language.rcl"
-    },
     "expr": {"patterns": [{"include": "#stmt"}, {"include": "#expr_op"}]},
     "expr_not_op": {"patterns": [{"include": "#expr_term"}]},
     "expr_op": {"patterns": [{"include": "#expr_not_op"}]},
     "expr_term": {
       "patterns": [
-        {"include": "#term_bracket"},
         {"include": "#term_brace"},
+        {"include": "#term_bracket"},
         {"include": "#term_parens"},
-        {"include": "#constant"},
-        {"include": "#term_string"}
+        {"include": "#term_string"},
+        {"include": "#term_number"},
+        {"include": "#term_constant"},
+        {"match": "[a-zA-Z_][a-zA-Z0-9_-]*", "name": "meta.structure.ident.rcl"}
       ]
     },
     "stmt": {
@@ -27,7 +25,7 @@
           "name": "meta.structure.let.rcl",
           "patterns": [
             {
-              "captures": {"1": {"name": "variable.rcl"}},
+              "captures": {"1": {"name": "variable.let.rcl"}},
               "match": "\\s+([a-zA-Z_][a-zA-Z0-9_-]*)\\s*="
             },
             {"include": "#expr"}
@@ -84,6 +82,14 @@
         {"include": "#expr"},
         {"match": ",", "name": "punctuation.separator.term_bracket.rcl"}
       ]
+    },
+    "term_constant": {
+      "match": "\\b(?:true|false|null)\\b",
+      "name": "constant.language.rcl"
+    },
+    "term_number": {
+      "match": "(?:0x|0b)?[0-9a-fA-F_]+(?:\\.[0-9a-fA-F_]*)?(?:[eE][+-]?[0-9_]+)?\\b",
+      "name": "constant.numeric.rcl"
     },
     "term_parens": {
       "begin": "\\(",

--- a/grammar/vscode/rcl.tmLanguage.json
+++ b/grammar/vscode/rcl.tmLanguage.json
@@ -1,5 +1,5 @@
 {
-  "patterns": [{"include": "#expr"}],
+  "patterns": [{"include": "#expr"}, {"include": "#comment"}],
   "repository": {
     "comment": {"match": "//.*$", "name": "comment.line.double-slash.rcl"},
     "constant": {
@@ -21,14 +21,17 @@
     "stmt": {
       "patterns": [
         {
-          "begin": "\\b(let)\\s+([^=;]+)\\s+=",
-          "beginCaptures": {
-            "1": {"name": "keyword.other.let.rcl"},
-            "2": {"name": "variable.rcl"}
-          },
+          "begin": "\\blet\\b",
+          "beginCaptures": {"0": {"name": "keyword.other.let.rcl"}},
           "end": ";",
           "name": "meta.structure.let.rcl",
-          "patterns": [{"include": "#expr"}]
+          "patterns": [
+            {
+              "captures": {"1": {"name": "variable.rcl"}},
+              "match": "\\s+([a-zA-Z_][a-zA-Z0-9_-]*)\\s*="
+            },
+            {"include": "#expr"}
+          ]
         },
         {
           "begin": "\\bassert\\b",

--- a/grammar/vscode/rcl.tmLanguage.json
+++ b/grammar/vscode/rcl.tmLanguage.json
@@ -1,22 +1,60 @@
 {
   "patterns": [{"include": "#expression"}],
   "repository": {
-    "array": {
-      "begin": "\\[",
-      "beginCaptures": {"0": {"name": "punctuation.definition.array.begin.rcl"}},
-      "end": "\\]",
-      "endCaptures": {"0": {"name": "punctuation.definition.array.end.rcl"}},
-      "name": "meta.structure.array.json",
-      "patterns": [
-        {"include": "#value"},
-        {"match": ",", "name": "punctuation.separator.array.rcl"}
-      ]
-    },
     "constant": {
       "match": "\\b(?:true|false|null)\\b",
       "name": "constant.language.rcl"
     },
-    "value": {"patterns": [{"include": "#array"}, {"include": "#constant"}]}
+    "expression": {
+      "patterns": [
+        {"include": "#term_bracket"},
+        {"include": "#term_brace"},
+        {"include": "#term_parens"},
+        {"include": "#constant"}
+      ]
+    },
+    "term_brace": {
+      "begin": "\\{",
+      "beginCaptures": {
+        "0": {"name": "punctuation.definition.term_brace.begin.rcl"}
+      },
+      "end": "\\}",
+      "endCaptures": {
+        "0": {"name": "punctuation.definition.term_brace.end.rcl"}
+      },
+      "name": "meta.structure.term_brace.rcl",
+      "patterns": [
+        {"include": "#expression"},
+        {"match": ",", "name": "punctuation.separator.term_brace.rcl"}
+      ]
+    },
+    "term_bracket": {
+      "begin": "\\[",
+      "beginCaptures": {
+        "0": {"name": "punctuation.definition.term_bracket.begin.rcl"}
+      },
+      "end": "\\]",
+      "endCaptures": {
+        "0": {"name": "punctuation.definition.term_bracket.end.rcl"}
+      },
+      "name": "meta.structure.term_bracket.rcl",
+      "patterns": [
+        {"include": "#expression"},
+        {"match": ",", "name": "punctuation.separator.term_bracket.rcl"}
+      ]
+    },
+    "term_parens": {
+      "begin": "\\(",
+      "beginCaptures": {
+        "0": {"name": "punctuation.definition.term_parens.begin.rcl"}
+      },
+      "end": "\\)",
+      "endCaptures": {
+        "0": {"name": "punctuation.definition.term_parens.end.rcl"}
+      },
+      "name": "meta.structure.term_parens.rcl",
+      "patterns": [{"include": "#expression"}]
+    }
   },
   "scopeName": "source.rcl"
 }

--- a/grammar/vscode/rcl.tmLanguage.json
+++ b/grammar/vscode/rcl.tmLanguage.json
@@ -1,6 +1,11 @@
 {
   "patterns": [{"include": "#expr"}],
   "repository": {
+    "comment": {
+      "begin": "//",
+      "end": "\n",
+      "name": "comment.line.double-slash.rcl"
+    },
     "constant": {
       "match": "\\b(?:true|false|null)\\b",
       "name": "constant.language.rcl"
@@ -20,7 +25,7 @@
     "string_hole": {
       "begin": "\\{",
       "end": "\\}",
-      "name": "interpolate.rcl",
+      "name": "string.interpolated.rcl",
       "patterns": [{"include": "#expr"}]
     },
     "term_brace": {

--- a/grammar/vscode/rcl.tmLanguage.json
+++ b/grammar/vscode/rcl.tmLanguage.json
@@ -2,9 +2,35 @@
   "patterns": [{"include": "#expr"}, {"include": "#comment"}],
   "repository": {
     "comment": {"match": "//.*$", "name": "comment.line.double-slash.rcl"},
-    "expr": {"patterns": [{"include": "#stmt"}, {"include": "#expr_op"}]},
+    "expr": {
+      "patterns": [
+        {"include": "#stmt"},
+        {"include": "#expr_if"},
+        {"include": "#expr_op"}
+      ]
+    },
+    "expr_binop": {
+      "match": "\\b(and|or)\\b",
+      "name": "keyword.operator.binop.rcl"
+    },
+    "expr_if": {
+      "begin": "\\bif\\b",
+      "beginCaptures": {"0": {"name": "keyword.control.if.rcl"}},
+      "end": "\\belse\\b",
+      "endCaptures": {"0": {"name": "keyword.control.else.rcl"}},
+      "name": "meta.structure.if.rcl",
+      "patterns": [{"include": "#expr"}]
+    },
+    "expr_import": {"match": "\\bimport\\b", "name": "keyword.other.rcl"},
     "expr_not_op": {"patterns": [{"include": "#expr_term"}]},
-    "expr_op": {"patterns": [{"include": "#expr_not_op"}]},
+    "expr_op": {
+      "patterns": [
+        {"include": "#expr_import"},
+        {"include": "#expr_unop"},
+        {"include": "#expr_binop"},
+        {"include": "#expr_not_op"}
+      ]
+    },
     "expr_term": {
       "patterns": [
         {"include": "#term_brace"},
@@ -16,6 +42,7 @@
         {"match": "[a-zA-Z_][a-zA-Z0-9_-]*", "name": "meta.structure.ident.rcl"}
       ]
     },
+    "expr_unop": {"match": "\\bnot\\b", "name": "keyword.operator.unop.rcl"},
     "stmt": {
       "patterns": [
         {
@@ -88,8 +115,17 @@
       "name": "constant.language.rcl"
     },
     "term_number": {
-      "match": "(?:0x|0b)?[0-9a-fA-F_]+(?:\\.[0-9a-fA-F_]*)?(?:[eE][+-]?[0-9_]+)?\\b",
-      "name": "constant.numeric.rcl"
+      "patterns": [
+        {
+          "match": "\\b0x[0-9a-fA-F_]*\\b",
+          "name": "constant.numeric.hexadecimal.rcl"
+        },
+        {"match": "\\b0b[01_]*\\b", "name": "constant.numeric.binary.rcl"},
+        {
+          "match": "\\b[0-9][0-9_]*(?:\\.[0-9_]*)?(?:[eE][+-]?[0-9_]*)?",
+          "name": "constant.numeric.decimal.rcl"
+        }
+      ]
     },
     "term_parens": {
       "begin": "\\(",

--- a/grammar/vscode/rcl.tmLanguage.json
+++ b/grammar/vscode/rcl.tmLanguage.json
@@ -179,23 +179,7 @@
       "name": "string.quoted.rcl",
       "patterns": [
         {
-          "begin": "\"",
-          "end": "\"",
-          "name": "string.quoted.double.rcl",
-          "patterns": [
-            {
-              "match": "\\\\u\\{[0-9a-fA-F_]+\\}",
-              "name": "constant.character.escape.unibrace.rcl"
-            },
-            {
-              "match": "\\\\u[0-9a-fA-F_]{4}",
-              "name": "constant.character.escape.rcl"
-            },
-            {"match": "\\\\.", "name": "constant.character.escape.single.rcl"}
-          ]
-        },
-        {
-          "begin": "\"\"\"",
+          "begin": "f\"\"\"",
           "end": "\"\"\"",
           "name": "string.quoted.triple.rcl",
           "patterns": [
@@ -207,7 +191,8 @@
               "match": "\\\\u[0-9a-fA-F_]{4}",
               "name": "constant.character.escape.rcl"
             },
-            {"match": "\\\\.", "name": "constant.character.escape.single.rcl"}
+            {"match": "\\\\.", "name": "constant.character.escape.single.rcl"},
+            {"include": "#string_hole"}
           ]
         },
         {
@@ -228,7 +213,7 @@
           ]
         },
         {
-          "begin": "f\"\"\"",
+          "begin": "\"\"\"",
           "end": "\"\"\"",
           "name": "string.quoted.triple.rcl",
           "patterns": [
@@ -240,8 +225,23 @@
               "match": "\\\\u[0-9a-fA-F_]{4}",
               "name": "constant.character.escape.rcl"
             },
-            {"match": "\\\\.", "name": "constant.character.escape.single.rcl"},
-            {"include": "#string_hole"}
+            {"match": "\\\\.", "name": "constant.character.escape.single.rcl"}
+          ]
+        },
+        {
+          "begin": "\"",
+          "end": "\"",
+          "name": "string.quoted.double.rcl",
+          "patterns": [
+            {
+              "match": "\\\\u\\{[0-9a-fA-F_]+\\}",
+              "name": "constant.character.escape.unibrace.rcl"
+            },
+            {
+              "match": "\\\\u[0-9a-fA-F_]{4}",
+              "name": "constant.character.escape.rcl"
+            },
+            {"match": "\\\\.", "name": "constant.character.escape.single.rcl"}
           ]
         }
       ]

--- a/grammar/vscode/rcl.tmLanguage.json
+++ b/grammar/vscode/rcl.tmLanguage.json
@@ -1,12 +1,13 @@
 {
-  "patterns": [{"include": "#expr"}, {"include": "#comment"}],
+  "patterns": [{"include": "#expr"}],
   "repository": {
     "comment": {"match": "//.*$", "name": "comment.line.double-slash.rcl"},
     "expr": {
       "patterns": [
         {"include": "#stmt"},
         {"include": "#expr_if"},
-        {"include": "#expr_op"}
+        {"include": "#expr_op"},
+        {"include": "#comment"}
       ]
     },
     "expr_binop": {
@@ -43,23 +44,78 @@
       ]
     },
     "expr_unop": {"match": "\\bnot\\b", "name": "keyword.operator.unop.rcl"},
+    "seq": {
+      "name": "meta.structure.seq.rcl",
+      "patterns": [
+        {"include": "#stmt"},
+        {"include": "#seq_for"},
+        {"include": "#seq_if"},
+        {"include": "#seq_kv"},
+        {"include": "#expr_op"},
+        {"include": "#comment"}
+      ]
+    },
+    "seq_for": {
+      "begin": "\\bfor\\b",
+      "beginCaptures": {"0": {"name": "keyword.control.for.rcl"}},
+      "end": ":",
+      "patterns": [
+        {
+          "begin": "(?<=\\bfor\\b)",
+          "end": "\\bin\\b",
+          "endCaptures": {"0": {"name": "keyword.control.in.rcl"}},
+          "patterns": [
+            {"match": "[a-zA-Z_][a-zA-Z0-9_]*", "name": "meta.declaration.rcl"}
+          ]
+        },
+        {
+          "begin": "(?<=\\bin\\b)",
+          "end": "(?=:)",
+          "patterns": [{"include": "#expr"}]
+        }
+      ]
+    },
+    "seq_if": {
+      "begin": "\\bif\\b",
+      "beginCaptures": {"0": {"name": "keyword.control.if.rcl"}},
+      "end": ":",
+      "patterns": [{"include": "#expr"}]
+    },
+    "seq_kv": {
+      "captures": {"1": {"name": "support.type.property-name.rcl"}},
+      "match": "\\b([a-zA-Z_][a-zA-Z0-9_]*)\\s+="
+    },
     "stmt": {
       "patterns": [
         {
           "begin": "\\blet\\b",
           "beginCaptures": {"0": {"name": "keyword.other.let.rcl"}},
-          "end": "=",
+          "end": ";",
           "name": "meta.structure.let.rcl",
           "patterns": [
             {
-              "begin": ":",
-              "end": "(?=[=])",
+              "begin": "(?<=\\blet\\b)",
+              "end": "[:=]",
+              "patterns": [
+                {
+                  "match": "[a-zA-Z_][a-zA-Z0-9_]*",
+                  "name": "meta.declaration.rcl"
+                }
+              ]
+            },
+            {
+              "begin": "(?<=:)",
+              "end": "=",
               "name": "meta.structure.annotation.rcl",
               "patterns": [
                 {"match": "[a-zA-Z_][a-zA-Z0-9_]*", "name": "storage.type.rcl"}
               ]
             },
-            {"match": "[a-zA-Z_][a-zA-Z0-9_]*", "name": "variable.let.rcl"}
+            {
+              "begin": "(?<=[=])",
+              "end": "(?=[;])",
+              "patterns": [{"include": "#expr"}]
+            }
           ]
         },
         {
@@ -86,33 +142,15 @@
     },
     "term_brace": {
       "begin": "\\{",
-      "beginCaptures": {
-        "0": {"name": "punctuation.definition.term_brace.begin.rcl"}
-      },
       "end": "\\}",
-      "endCaptures": {
-        "0": {"name": "punctuation.definition.term_brace.end.rcl"}
-      },
-      "name": "meta.structure.term_brace.rcl",
-      "patterns": [
-        {"include": "#expr"},
-        {"match": ",", "name": "punctuation.separator.term_brace.rcl"}
-      ]
+      "name": "meta.structure.brace.rcl",
+      "patterns": [{"include": "#seq"}]
     },
     "term_bracket": {
       "begin": "\\[",
-      "beginCaptures": {
-        "0": {"name": "punctuation.definition.term_bracket.begin.rcl"}
-      },
       "end": "\\]",
-      "endCaptures": {
-        "0": {"name": "punctuation.definition.term_bracket.end.rcl"}
-      },
-      "name": "meta.structure.term_bracket.rcl",
-      "patterns": [
-        {"include": "#expr"},
-        {"match": ",", "name": "punctuation.separator.term_bracket.rcl"}
-      ]
+      "name": "meta.structure.bracket.rcl",
+      "patterns": [{"include": "#seq"}]
     },
     "term_constant": {
       "match": "\\b(?:true|false|null)\\b",
@@ -133,14 +171,8 @@
     },
     "term_parens": {
       "begin": "\\(",
-      "beginCaptures": {
-        "0": {"name": "punctuation.definition.term_parens.begin.rcl"}
-      },
       "end": "\\)",
-      "endCaptures": {
-        "0": {"name": "punctuation.definition.term_parens.end.rcl"}
-      },
-      "name": "meta.structure.term_parens.rcl",
+      "name": "meta.structure.parens.rcl",
       "patterns": [{"include": "#expr"}]
     },
     "term_string": {

--- a/grammar/vscode/rcl.tmLanguage.json
+++ b/grammar/vscode/rcl.tmLanguage.json
@@ -139,8 +139,14 @@
     },
     "string_hole": {
       "begin": "\\{",
+      "beginCaptures": {
+        "0": {"name": "punctuation.definition.template-expression.begin.rcl"}
+      },
       "end": "\\}",
-      "name": "string.interpolated.rcl",
+      "endCaptures": {
+        "0": {"name": "punctuation.definition.template-expression.end.rcl"}
+      },
+      "name": "meta.embedded.expression.rcl",
       "patterns": [{"include": "#expr"}]
     },
     "term_brace": {

--- a/grammar/vscode/rcl.tmLanguage.rcl
+++ b/grammar/vscode/rcl.tmLanguage.rcl
@@ -1,0 +1,39 @@
+// RCL -- A reasonable configuration language.
+// Copyright 2025 Ruud van Asseldonk
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// A copy of the License has been included in the root of the repository.
+
+{
+  scopeName = "source.rcl",
+  patterns = [{ include = "#expression" }],
+
+  repository = {
+    array = {
+      begin = "\\[",
+      beginCaptures = {
+        "0": { name = "punctuation.definition.array.begin.rcl" },
+      },
+      end = "\\]",
+      endCaptures = { "0": { name = "punctuation.definition.array.end.rcl" } },
+      name = "meta.structure.array.json",
+      patterns = [
+        { include = "#value" },
+        { match = ",", name = "punctuation.separator.array.rcl" },
+      ],
+    },
+
+    constant = {
+      match = "\\b(?:true|false|null)\\b",
+      name = "constant.language.rcl",
+    },
+
+    value = {
+      patterns = [
+        { include = "#array" },
+        { include = "#constant" },
+      ],
+    },
+  },
+}

--- a/grammar/vscode/rcl.tmLanguage.rcl
+++ b/grammar/vscode/rcl.tmLanguage.rcl
@@ -7,7 +7,8 @@
 
 // This TextMate grammar is structured to reflect the Bison grammar in
 // grammar.y, with the rules in the repository here matching the rules in the
-// Bison grammar by name and structure where possible.
+// Bison grammar by name and structure where possible. There are some links to
+// helpful documentation in the grammars directory's readme.
 
 {
   scopeName = "source.rcl",
@@ -57,8 +58,7 @@
     string_hole = {
       begin = "\\{",
       end = "\\}",
-      // TODO: Pick the relevant scope name.
-      name = "interpolate.rcl",
+      name = "string.interpolated.rcl",
       patterns = [{ include = "#expr" }],
     },
 
@@ -119,6 +119,12 @@
         // - number
         // - ident
       ],
+    },
+
+    // Comment is a magic rule in TextMate grammars, it is allowed anywhere.
+    comment = {
+      name = "comment.line.double-slash.rcl",
+      match = "//.*$",
     },
   },
 }

--- a/grammar/vscode/rcl.tmLanguage.rcl
+++ b/grammar/vscode/rcl.tmLanguage.rcl
@@ -88,9 +88,9 @@
 
     expr = {
       patterns = [
+        { include = "#stmt" },
         { include = "#expr_op" },
         // TODO: Add:
-        // - stmt
         // - expr_if
       ],
     },
@@ -126,6 +126,41 @@
         // TODO: To add:
         // - number
         // - ident
+      ],
+    },
+
+    stmt = {
+      patterns = [
+        {
+          // The rules for what constitutes an identifier are more strict in
+          // reality, but highlighting should generally be a bit laxer so that
+          // writing an invalid identifier does not cause the document to stop
+          // being highlighted.
+          begin = "\\b(let)\\s+([^=;]+)\\s+=",
+          end = ";",
+          beginCaptures = {
+            "1": { name = "keyword.other.let.rcl" },
+            "2": { name = "variable.rcl" },
+          },
+          name = "meta.structure.let.rcl",
+          patterns = [{ include = "#expr" }],
+        },
+        {
+          // The structure is more complex than this, but we don't capture that
+          // in the grammar for highlighting.
+          begin = "\\bassert\\b",
+          end = ";",
+          beginCaptures = { "0": { name = "keyword.control.assert.rcl" } },
+          name = "meta.structure.assert.rcl",
+          patterns = [{ include = "#expr" }],
+        },
+        {
+          begin = "\\btrace\\b",
+          end = ";",
+          beginCaptures = { "0": { name = "keyword.control.trace.rcl" } },
+          name = "meta.structure.trace.rcl",
+          patterns = [{ include = "#expr" }],
+        },
       ],
     },
 

--- a/grammar/vscode/rcl.tmLanguage.rcl
+++ b/grammar/vscode/rcl.tmLanguage.rcl
@@ -22,7 +22,7 @@
     { include = "#expr" },
   ],
 
-  let identifier = "[a-zA-Z_][a-zA-Z0-9_]*";
+  let identifier = "[a-zA-Z_][a-zA-Z0-9_-]*";
 
   // In some places, like after `let` and `for`, we can match identifiers, but
   // we don't assign them the `variable` scope. Some themes highlight it, but in

--- a/grammar/vscode/rcl.tmLanguage.rcl
+++ b/grammar/vscode/rcl.tmLanguage.rcl
@@ -83,10 +83,18 @@
       ],
     },
 
-    constant = {
+    term_constant = {
       // ?: means a non-captured group.
       match = "\\b(?:true|false|null)\\b",
       name = "constant.language.rcl",
+    },
+
+    term_number = {
+      // The regex for number is more lax than what the RCL lexer/parser allow,
+      // such that writing something invalid does not break highlighting of the
+      // entire document. ?: introduces a non-captured group.
+      match = "(?:0x|0b)?[0-9a-fA-F_]+(?:\\.[0-9a-fA-F_]*)?(?:[eE][+-]?[0-9_]+)?\\b",
+      name = "constant.numeric.rcl",
     },
 
     expr = {
@@ -121,14 +129,19 @@
 
     expr_term = {
       patterns = [
-        { include = "#term_bracket" },
         { include = "#term_brace" },
+        { include = "#term_bracket" },
         { include = "#term_parens" },
-        { include = "#constant" },
         { include = "#term_string" },
-        // TODO: To add:
-        // - number
-        // - ident
+        { include = "#term_number" },
+        { include = "#term_constant" },
+        {
+          // We don't need to highlight identifiers, so we don't really need a
+          // rule for it, but we include it for completeness and to allow other
+          // extensions to potentially do something with it.
+          name = "meta.structure.ident.rcl",
+          match = "[a-zA-Z_][a-zA-Z0-9_-]*",
+        },
       ],
     },
 

--- a/grammar/vscode/rcl.tmLanguage.rcl
+++ b/grammar/vscode/rcl.tmLanguage.rcl
@@ -237,7 +237,10 @@
               begin = "(?<=:)",
               end = "=",
               patterns = [
-                { match = f"{identifier}", name = "storage.type.rcl" },
+                // We don't use `storage.type` because it's not really a type
+                // like that like it is in C. The Rust grammar uses this scope
+                // so we'll use it as well.
+                { match = f"{identifier}", name = "entity.name.type.rcl" },
               ],
             },
             // Finally, the expression part, the end of which we need to match
@@ -313,7 +316,9 @@
       match = f"\\b({identifier})\\s+=",
       captures = {
         // This scope is the same one as used by the json grammar for keys.
-        "1": { name = "support.type.property-name.rcl" },
+        // Some themes special-case json so let's include this to make it behave
+        // similarly.
+        "1": { name = "support.type.property-name.json.rcl" },
       },
     },
 

--- a/grammar/vscode/rcl.tmLanguage.rcl
+++ b/grammar/vscode/rcl.tmLanguage.rcl
@@ -20,28 +20,14 @@
   scopeName = "source.rcl",
   patterns = [
     { include = "#expr" },
-    { include = "#comment" },
   ],
 
   let identifier = "[a-zA-Z_][a-zA-Z0-9_]*";
 
-  // First we define some helpers, because all collections are very similar,
-  // and it's quite verbose to define in TextMate grammar.
-  let patterns_sep_comma = name => [
-    { include = "#expr" },
-    { match = ",", name = f"punctuation.separator.{name}.rcl" },
-  ];
-
-  let delimited = (name, begin, end, patterns) => {
-    begin = begin,
-    beginCaptures = {
-      "0": { name = f"punctuation.definition.{name}.begin.rcl" },
-    },
-    end = end,
-    endCaptures = { "0": { name = f"punctuation.definition.{name}.end.rcl" } },
-    name = f"meta.structure.{name}.rcl",
-    patterns = patterns(name),
-  };
+  // In some places, like after `let` and `for`, we can match identifiers, but
+  // we don't assign them the `variable` scope. Some themes highlight it, but in
+  // my opinion it makes the document too cluttered when everything lights up.
+  let inner_ident = { match = f"{identifier}", name = "meta.declaration.rcl" };
 
   let make_term_string = (name, begin, end, patterns) => {
       name = name,
@@ -65,14 +51,26 @@
   };
 
   repository = {
-    term_bracket = delimited("term_bracket", "\\[", "\\]", patterns_sep_comma),
-    term_brace = delimited("term_brace", "\\{", "\\}", patterns_sep_comma),
-    term_parens = delimited(
-      "term_parens",
-      "\\(",
-      "\\)",
-      _name => [{ include = "#expr" }],
-    ),
+    term_bracket = {
+      name = "meta.structure.bracket.rcl",
+      begin = "\\[",
+      end = "\\]",
+      patterns = [{ include = "#seq" }],
+    },
+
+    term_brace = {
+      name = "meta.structure.brace.rcl",
+      begin = "\\{",
+      end = "\\}",
+      patterns = [{ include = "#seq" }],
+    },
+
+    term_parens = {
+      name = "meta.structure.parens.rcl",
+      begin = "\\(",
+      end = "\\)",
+      patterns = [{ include = "#expr" }],
+    },
 
     string_hole = {
       begin = "\\{",
@@ -130,6 +128,7 @@
         { include = "#stmt" },
         { include = "#expr_if" },
         { include = "#expr_op" },
+        { include = "#comment" },
       ],
     },
 
@@ -150,10 +149,12 @@
     expr_op = {
       patterns = [
         { include = "#expr_import" },
-        // TODO: expr_function
         { include = "#expr_unop" },
         { include = "#expr_binop" },
         { include = "#expr_not_op" },
+        // In the grammar we also have function expressions, but we don't need
+        // to define anything explicitly here; we could match on the fat arrow
+        // but leaving the entire thing an `expr` scope works fine.
       ],
     },
 
@@ -170,10 +171,9 @@
     expr_not_op = {
       patterns = [
         { include = "#expr_term" },
-        // TODO: Add:
-        // - call
-        // - array index
-        // - field access
+        // In the grammar we also have function calls, array indexing, and field
+        // access, but we don't need to explicitly define them here, we just
+        // leave the punctuation tokens unmatched.
       ],
     },
 
@@ -206,27 +206,33 @@
           // more productive to match only until `=`, and let the regular `expr`
           // rule handle everything after it on both sides of the `;`.
           begin = "\\blet\\b",
-          end = "=",
+          end = ";",
           beginCaptures = { "0": { name = "keyword.other.let.rcl" } },
           name = "meta.structure.let.rcl",
           patterns = [
+            // The identifier part, the start of which we match with a
+            // lookbehind because it's already consumed by the outer rule.
+            {
+              begin = "(?<=\\blet\\b)",
+              end = "[:=]",
+              patterns = [inner_ident],
+            },
+            // Optionally, a type annotation part, which we again match using
+            // a lookbehind.
             {
               name = "meta.structure.annotation.rcl",
-              begin = ":",
-              // The end is where the `=` starts, but we can't consume it,
-              // because the end pattern of the surrounding let already needs
-              // to consume it, so we use a lookahead.
-              end = "(?=[=])",
+              begin = "(?<=:)",
+              end = "=",
               patterns = [
-                {
-                  match = f"{identifier}",
-                  name = "storage.type.rcl"
-                }
+                { match = f"{identifier}", name = "storage.type.rcl" }
               ],
             },
+            // Finally, the expression part, the end of which we need to match
+            // using a lookahead because it's again consumed by the outer rule.
             {
-              match = f"{identifier}",
-              name = "variable.let.rcl",
+              begin = "(?<=[=])",
+              end = "(?=[;])",
+              patterns = [{ include = "#expr" }],
             }
           ],
         },
@@ -247,6 +253,55 @@
           patterns = [{ include = "#expr" }],
         },
       ],
+    },
+
+    seq = {
+      name = "meta.structure.seq.rcl",
+      patterns = [
+        { include = "#stmt" },
+        { include = "#seq_for" },
+        { include = "#seq_if" },
+        { include = "#seq_kv" },
+        { include = "#expr_op" },
+        { include = "#comment" },
+      ],
+    },
+
+    seq_for = {
+      begin = "\\bfor\\b",
+      end = ":",
+      beginCaptures = { "0": { name = "keyword.control.for.rcl" } },
+      // For the two sections inside, we use lookbehind to match the start of
+      // the group, so we don't consume the match, because we can consume every
+      // match only once.
+      patterns = [
+        {
+          begin = "(?<=\\bfor\\b)",
+          end = "\\bin\\b",
+          endCaptures = { "0": { name = "keyword.control.in.rcl" } },
+          patterns = [inner_ident],
+        },
+        {
+          begin = "(?<=\\bin\\b)",
+          end = "(?=:)",
+          patterns = [{ include = "#expr" }],
+        }
+      ],
+    },
+
+    seq_if = {
+      begin = "\\bif\\b",
+      end = ":",
+      beginCaptures = { "0": { name = "keyword.control.if.rcl" } },
+      patterns = [{ include = "#expr" }],
+    },
+
+    seq_kv = {
+      match = f"\\b({identifier})\\s+=",
+      captures = {
+        // This scope is the same one as used by the json grammar for keys.
+        "1": { name = "support.type.property-name.rcl" },
+      },
     },
 
     // Comment is a magic rule in TextMate grammars, it is allowed anywhere.

--- a/grammar/vscode/rcl.tmLanguage.rcl
+++ b/grammar/vscode/rcl.tmLanguage.rcl
@@ -12,7 +12,10 @@
 
 {
   scopeName = "source.rcl",
-  patterns = [{ include = "#expr" }],
+  patterns = [
+    { include = "#expr" },
+    { include = "#comment" },
+  ],
 
   // First we define some helpers, because all collections are very similar,
   // and it's quite verbose to define in TextMate grammar.
@@ -132,18 +135,22 @@
     stmt = {
       patterns = [
         {
-          // The rules for what constitutes an identifier are more strict in
-          // reality, but highlighting should generally be a bit laxer so that
-          // writing an invalid identifier does not cause the document to stop
-          // being highlighted.
-          begin = "\\b(let)\\s+([^=;]+)\\s+=",
+          // The rule for a let statement is more complex than this, with the
+          // identifier and `=`, but we don't make them part of the `begin`
+          // match so that `let` can be highlighted immediately after you type
+          // it.
+          begin = "\\blet\\b",
           end = ";",
-          beginCaptures = {
-            "1": { name = "keyword.other.let.rcl" },
-            "2": { name = "variable.rcl" },
-          },
+          beginCaptures = { "0": { name = "keyword.other.let.rcl" } },
           name = "meta.structure.let.rcl",
-          patterns = [{ include = "#expr" }],
+          patterns = [
+            // Between the opening `let` and `=`, we get the variable name.
+            {
+              match = "\\s+([a-zA-Z_][a-zA-Z0-9_-]*)\\s*=",
+              captures = { "1": { name = "variable.let.rcl" } },
+            },
+            { include = "#expr" },
+          ],
         },
         {
           // The structure is more complex than this, but we don't capture that

--- a/grammar/vscode/rcl.tmLanguage.rcl
+++ b/grammar/vscode/rcl.tmLanguage.rcl
@@ -33,15 +33,23 @@
   };
 
   let make_term_string = (name, begin, end, patterns) => {
+      name = name,
       begin = begin,
       end = end,
-      name = name,
       patterns = [
         {
-          name = "constant.character.escape.rcl",
-          match = "\\.",
+          name = "constant.character.escape.unibrace.rcl",
+          match = "\\\\u\\{[0-9a-fA-F_]+\\}",
         },
-        ..patterns,
+        {
+          name = "constant.character.escape.rcl",
+          match = "\\\\u[0-9a-fA-F_]{4}",
+        },
+        {
+          name = "constant.character.escape.single.rcl",
+          match = "\\\\.",
+        },
+        for include_pattern in patterns: { include = include_pattern }
       ],
   };
 
@@ -67,8 +75,8 @@
       patterns = [
         make_term_string("string.quoted.double.rcl", "\"", "\"", []),
         make_term_string("string.quoted.triple.rcl", "\"\"\"", "\"\"\"", []),
-        make_term_string("string.quoted.double.rcl", "f\"", "\"", [{include = "#string_hole"}]),
-        make_term_string("string.quoted.triple.rcl", "f\"\"\"", "\"\"\"", [{include = "#string_hole"}]),
+        make_term_string("string.quoted.double.rcl", "f\"", "\"", ["#string_hole"]),
+        make_term_string("string.quoted.triple.rcl", "f\"\"\"", "\"\"\"", ["#string_hole"]),
       ],
     },
 

--- a/grammar/vscode/rcl.tmLanguage.rcl
+++ b/grammar/vscode/rcl.tmLanguage.rcl
@@ -30,24 +30,24 @@
   let inner_ident = { match = f"{identifier}", name = "meta.declaration.rcl" };
 
   let make_term_string = (name, begin, end, patterns) => {
-      name = name,
-      begin = begin,
-      end = end,
-      patterns = [
-        {
-          name = "constant.character.escape.unibrace.rcl",
-          match = "\\\\u\\{[0-9a-fA-F_]+\\}",
-        },
-        {
-          name = "constant.character.escape.rcl",
-          match = "\\\\u[0-9a-fA-F_]{4}",
-        },
-        {
-          name = "constant.character.escape.single.rcl",
-          match = "\\\\.",
-        },
-        for include_pattern in patterns: { include = include_pattern }
-      ],
+    name = name,
+    begin = begin,
+    end = end,
+    patterns = [
+      {
+        name = "constant.character.escape.unibrace.rcl",
+        match = "\\\\u\\{[0-9a-fA-F_]+\\}",
+      },
+      {
+        name = "constant.character.escape.rcl",
+        match = "\\\\u[0-9a-fA-F_]{4}",
+      },
+      {
+        name = "constant.character.escape.single.rcl",
+        match = "\\\\.",
+      },
+      for include_pattern in patterns: { include = include_pattern },
+    ],
   };
 
   repository = {
@@ -84,8 +84,18 @@
       patterns = [
         make_term_string("string.quoted.double.rcl", "\"", "\"", []),
         make_term_string("string.quoted.triple.rcl", "\"\"\"", "\"\"\"", []),
-        make_term_string("string.quoted.double.rcl", "f\"", "\"", ["#string_hole"]),
-        make_term_string("string.quoted.triple.rcl", "f\"\"\"", "\"\"\"", ["#string_hole"]),
+        make_term_string(
+          "string.quoted.double.rcl",
+          "f\"",
+          "\"",
+          ["#string_hole"],
+        ),
+        make_term_string(
+          "string.quoted.triple.rcl",
+          "f\"\"\"",
+          "\"\"\"",
+          ["#string_hole"],
+        ),
       ],
     },
 
@@ -224,7 +234,7 @@
               begin = "(?<=:)",
               end = "=",
               patterns = [
-                { match = f"{identifier}", name = "storage.type.rcl" }
+                { match = f"{identifier}", name = "storage.type.rcl" },
               ],
             },
             // Finally, the expression part, the end of which we need to match
@@ -233,7 +243,7 @@
               begin = "(?<=[=])",
               end = "(?=[;])",
               patterns = [{ include = "#expr" }],
-            }
+            },
           ],
         },
         {
@@ -285,7 +295,7 @@
           begin = "(?<=\\bin\\b)",
           end = "(?=:)",
           patterns = [{ include = "#expr" }],
-        }
+        },
       ],
     },
 

--- a/grammar/vscode/rcl.tmLanguage.rcl
+++ b/grammar/vscode/rcl.tmLanguage.rcl
@@ -9,29 +9,43 @@
   scopeName = "source.rcl",
   patterns = [{ include = "#expression" }],
 
-  repository = {
-    array = {
-      begin = "\\[",
-      beginCaptures = {
-        "0": { name = "punctuation.definition.array.begin.rcl" },
-      },
-      end = "\\]",
-      endCaptures = { "0": { name = "punctuation.definition.array.end.rcl" } },
-      name = "meta.structure.array.json",
-      patterns = [
-        { include = "#value" },
-        { match = ",", name = "punctuation.separator.array.rcl" },
-      ],
+  // First we define some helpers, because all collections are very similar,
+  // and it's quite verbose to define in TextMate grammar.
+  let patterns_sep_comma = name => [
+    { include = "#expression" },
+    { match = ",", name = f"punctuation.separator.{name}.rcl" },
+  ];
+  let delimited = (name, begin, end, patterns) => {
+    begin = begin,
+    beginCaptures = {
+      "0": { name = f"punctuation.definition.{name}.begin.rcl" },
     },
+    end = end,
+    endCaptures = { "0": { name = f"punctuation.definition.{name}.end.rcl" } },
+    name = f"meta.structure.{name}.rcl",
+    patterns = patterns(name),
+  };
+
+  repository = {
+    term_bracket = delimited("term_bracket", "\\[", "\\]", patterns_sep_comma),
+    term_brace = delimited("term_brace", "\\{", "\\}", patterns_sep_comma),
+    term_parens = delimited(
+      "term_parens",
+      "\\(",
+      "\\)",
+      _name => [{ include = "#expression" }],
+    ),
 
     constant = {
       match = "\\b(?:true|false|null)\\b",
       name = "constant.language.rcl",
     },
 
-    value = {
+    expression = {
       patterns = [
-        { include = "#array" },
+        { include = "#term_bracket" },
+        { include = "#term_brace" },
+        { include = "#term_parens" },
         { include = "#constant" },
       ],
     },

--- a/grammar/vscode/rcl.tmLanguage.rcl
+++ b/grammar/vscode/rcl.tmLanguage.rcl
@@ -7,8 +7,14 @@
 
 // This TextMate grammar is structured to reflect the Bison grammar in
 // grammar.y, with the rules in the repository here matching the rules in the
-// Bison grammar by name and structure where possible. There are some links to
-// helpful documentation in the grammars directory's readme.
+// Bison grammar by name and structure where possible. Note that TextMate rules
+// are not production rules though! They indicate nesting, but not sequencing,
+// e.g. the expr_op and expr_binop rules here have no need to be distinct rules,
+// they match the keywords anywhere, but we still keep them distinct in order to
+// match the Bison grammar as closely as possible, to make it more obvious that
+// they are in sync.
+//
+// There are links to helpful documentation in the grammars directory's readme.
 
 {
   scopeName = "source.rcl",
@@ -92,29 +98,71 @@
     term_number = {
       // The regex for number is more lax than what the RCL lexer/parser allow,
       // such that writing something invalid does not break highlighting of the
-      // entire document. ?: introduces a non-captured group.
-      match = "(?:0x|0b)?[0-9a-fA-F_]+(?:\\.[0-9a-fA-F_]*)?(?:[eE][+-]?[0-9_]+)?\\b",
-      name = "constant.numeric.rcl",
+      // entire document. We do split out int with possible prefixes, such that
+      // e.g. `a` on its own is not considered a hex number.
+      patterns = [
+        {
+          name = "constant.numeric.hexadecimal.rcl",
+          match = "\\b0x[0-9a-fA-F_]*\\b",
+        },
+        {
+          name = "constant.numeric.binary.rcl",
+          match = "\\b0b[01_]*\\b",
+        },
+        {
+          name = "constant.numeric.decimal.rcl",
+          // The structure of this regex is chosen such that a prefix of a
+          // number still matches, even when it's not valid for the RCL lexer.
+          // For example, `42.` and `4.2e` match. This ensures that while you
+          // are typing `42.0` or `4.2e1`, the number does not become
+          // un-highlighted as soon as you type the `.` or the `e`. There is no
+          // word boundary anchor at the end because it eats the `.` if there is
+          // one.
+          match = "\\b[0-9][0-9_]*(?:\\.[0-9_]*)?(?:[eE][+-]?[0-9_]*)?",
+        },
+      ],
     },
 
     expr = {
       patterns = [
         { include = "#stmt" },
+        { include = "#expr_if" },
         { include = "#expr_op" },
-        // TODO: Add:
-        // - expr_if
       ],
+    },
+
+    expr_if = {
+      begin = "\\bif\\b",
+      end = "\\belse\\b",
+      beginCaptures = { "0": { name = "keyword.control.if.rcl" } },
+      endCaptures = { "0": { name = "keyword.control.else.rcl" } },
+      name = "meta.structure.if.rcl",
+      patterns = [{ include = "#expr" }],
+    },
+
+    expr_import = {
+      match = "\\bimport\\b",
+      name = "keyword.other.rcl",
     },
 
     expr_op = {
       patterns = [
-        // TODO: Add:
-        // - import
-        // - function
-        // - unop
-        // - binop
+        { include = "#expr_import" },
+        // TODO: expr_function
+        { include = "#expr_unop" },
+        { include = "#expr_binop" },
         { include = "#expr_not_op" },
       ],
+    },
+
+    expr_unop = {
+      match = "\\bnot\\b",
+      name = "keyword.operator.unop.rcl",
+    },
+
+    expr_binop = {
+      match = "\\b(and|or)\\b",
+      name = "keyword.operator.binop.rcl",
     },
 
     expr_not_op = {

--- a/grammar/vscode/rcl.tmLanguage.rcl
+++ b/grammar/vscode/rcl.tmLanguage.rcl
@@ -19,6 +19,7 @@
     { include = "#expr" },
     { match = ",", name = f"punctuation.separator.{name}.rcl" },
   ];
+
   let delimited = (name, begin, end, patterns) => {
     begin = begin,
     beginCaptures = {
@@ -30,6 +31,19 @@
     patterns = patterns(name),
   };
 
+  let make_term_string = (name, begin, end, patterns) => {
+      begin = begin,
+      end = end,
+      name = name,
+      patterns = [
+        {
+          name = "constant.character.escape.rcl",
+          match = "\\.",
+        },
+        ..patterns,
+      ],
+  };
+
   repository = {
     term_bracket = delimited("term_bracket", "\\[", "\\]", patterns_sep_comma),
     term_brace = delimited("term_brace", "\\{", "\\}", patterns_sep_comma),
@@ -39,6 +53,24 @@
       "\\)",
       _name => [{ include = "#expr" }],
     ),
+
+    string_hole = {
+      begin = "\\{",
+      end = "\\}",
+      // TODO: Pick the relevant scope name.
+      name = "interpolate.rcl",
+      patterns = [{ include = "#expr" }],
+    },
+
+    term_string = {
+      name = "string.quoted.rcl",
+      patterns = [
+        make_term_string("string.quoted.double.rcl", "\"", "\"", []),
+        make_term_string("string.quoted.triple.rcl", "\"\"\"", "\"\"\"", []),
+        make_term_string("string.quoted.double.rcl", "f\"", "\"", [{include = "#string_hole"}]),
+        make_term_string("string.quoted.triple.rcl", "f\"\"\"", "\"\"\"", [{include = "#string_hole"}]),
+      ],
+    },
 
     constant = {
       // ?: means a non-captured group.
@@ -82,9 +114,8 @@
         { include = "#term_brace" },
         { include = "#term_parens" },
         { include = "#constant" },
+        { include = "#term_string" },
         // TODO: To add:
-        // - fstring
-        // - string
         // - number
         // - ident
       ],

--- a/grammar/vscode/rcl.tmLanguage.rcl
+++ b/grammar/vscode/rcl.tmLanguage.rcl
@@ -5,14 +5,18 @@
 // you may not use this file except in compliance with the License.
 // A copy of the License has been included in the root of the repository.
 
+// This TextMate grammar is structured to reflect the Bison grammar in
+// grammar.y, with the rules in the repository here matching the rules in the
+// Bison grammar by name and structure where possible.
+
 {
   scopeName = "source.rcl",
-  patterns = [{ include = "#expression" }],
+  patterns = [{ include = "#expr" }],
 
   // First we define some helpers, because all collections are very similar,
   // and it's quite verbose to define in TextMate grammar.
   let patterns_sep_comma = name => [
-    { include = "#expression" },
+    { include = "#expr" },
     { match = ",", name = f"punctuation.separator.{name}.rcl" },
   ];
   let delimited = (name, begin, end, patterns) => {
@@ -33,20 +37,56 @@
       "term_parens",
       "\\(",
       "\\)",
-      _name => [{ include = "#expression" }],
+      _name => [{ include = "#expr" }],
     ),
 
     constant = {
+      // ?: means a non-captured group.
       match = "\\b(?:true|false|null)\\b",
       name = "constant.language.rcl",
     },
 
-    expression = {
+    expr = {
+      patterns = [
+        { include = "#expr_op" },
+        // TODO: Add:
+        // - stmt
+        // - expr_if
+      ],
+    },
+
+    expr_op = {
+      patterns = [
+        // TODO: Add:
+        // - import
+        // - function
+        // - unop
+        // - binop
+        { include = "#expr_not_op" },
+      ],
+    },
+
+    expr_not_op = {
+      patterns = [
+        { include = "#expr_term" },
+        // TODO: Add:
+        // - call
+        // - array index
+        // - field access
+      ],
+    },
+
+    expr_term = {
       patterns = [
         { include = "#term_bracket" },
         { include = "#term_brace" },
         { include = "#term_parens" },
         { include = "#constant" },
+        // TODO: To add:
+        // - fstring
+        // - string
+        // - number
+        // - ident
       ],
     },
   },

--- a/grammar/vscode/rcl.tmLanguage.rcl
+++ b/grammar/vscode/rcl.tmLanguage.rcl
@@ -82,20 +82,23 @@
     term_string = {
       name = "string.quoted.rcl",
       patterns = [
-        make_term_string("string.quoted.double.rcl", "\"", "\"", []),
-        make_term_string("string.quoted.triple.rcl", "\"\"\"", "\"\"\"", []),
-        make_term_string(
-          "string.quoted.double.rcl",
-          "f\"",
-          "\"",
-          ["#string_hole"],
-        ),
+        // The order of the patterns matters, we need to put the largest
+        // possible match first: f-strings go before normal strings, triple
+        // before double.
         make_term_string(
           "string.quoted.triple.rcl",
           "f\"\"\"",
           "\"\"\"",
           ["#string_hole"],
         ),
+        make_term_string(
+          "string.quoted.double.rcl",
+          "f\"",
+          "\"",
+          ["#string_hole"],
+        ),
+        make_term_string("string.quoted.triple.rcl", "\"\"\"", "\"\"\"", []),
+        make_term_string("string.quoted.double.rcl", "\"", "\"", []),
       ],
     },
 

--- a/grammar/vscode/rcl.tmLanguage.rcl
+++ b/grammar/vscode/rcl.tmLanguage.rcl
@@ -23,6 +23,8 @@
     { include = "#comment" },
   ],
 
+  let identifier = "[a-zA-Z_][a-zA-Z0-9_]*";
+
   // First we define some helpers, because all collections are very similar,
   // and it's quite verbose to define in TextMate grammar.
   let patterns_sep_comma = name => [
@@ -188,7 +190,7 @@
           // rule for it, but we include it for completeness and to allow other
           // extensions to potentially do something with it.
           name = "meta.structure.ident.rcl",
-          match = "[a-zA-Z_][a-zA-Z0-9_-]*",
+          match = f"{identifier}",
         },
       ],
     },
@@ -199,18 +201,33 @@
           // The rule for a let statement is more complex than this, with the
           // identifier and `=`, but we don't make them part of the `begin`
           // match so that `let` can be highlighted immediately after you type
-          // it.
+          // it. Initially we had the rule run until the closing `;`, but that
+          // makes it difficult match the inner structure before the `=`; it's
+          // more productive to match only until `=`, and let the regular `expr`
+          // rule handle everything after it on both sides of the `;`.
           begin = "\\blet\\b",
-          end = ";",
+          end = "=",
           beginCaptures = { "0": { name = "keyword.other.let.rcl" } },
           name = "meta.structure.let.rcl",
           patterns = [
-            // Between the opening `let` and `=`, we get the variable name.
             {
-              match = "\\s+([a-zA-Z_][a-zA-Z0-9_-]*)\\s*=",
-              captures = { "1": { name = "variable.let.rcl" } },
+              name = "meta.structure.annotation.rcl",
+              begin = ":",
+              // The end is where the `=` starts, but we can't consume it,
+              // because the end pattern of the surrounding let already needs
+              // to consume it, so we use a lookahead.
+              end = "(?=[=])",
+              patterns = [
+                {
+                  match = f"{identifier}",
+                  name = "storage.type.rcl"
+                }
+              ],
             },
-            { include = "#expr" },
+            {
+              match = f"{identifier}",
+              name = "variable.let.rcl",
+            }
           ],
         },
         {

--- a/grammar/vscode/rcl.tmLanguage.rcl
+++ b/grammar/vscode/rcl.tmLanguage.rcl
@@ -75,7 +75,16 @@
     string_hole = {
       begin = "\\{",
       end = "\\}",
-      name = "string.interpolated.rcl",
+      // Note, the name `meta.embedded` is magic, it makes VSCode ignore the
+      // parent scope for coloring, so that bare identifiers show up like
+      // they do elsewhere in the document; not colored like a string.
+      name = "meta.embedded.expression.rcl",
+      beginCaptures = {
+        "0": { name = "punctuation.definition.template-expression.begin.rcl" },
+      },
+      endCaptures = {
+        "0": { name = "punctuation.definition.template-expression.end.rcl" },
+      },
       patterns = [{ include = "#expr" }],
     },
 

--- a/website/index.html
+++ b/website/index.html
@@ -617,7 +617,7 @@
       <p>RCL is usable and useful, well-tested, and well-documented. It is still
       pre-1.0, though backwards-incompatible changes have been rare in the past
       years. Syntax highlighting is available for major editors like Vim, Emacs,
-      Helix, and Zed. RCL is a community project without commercial support.
+      Helix, VSCode, and Zed. RCL is a community project without commercial support.
       </p>
     </div>
     <div class="span-full">

--- a/website/index.html
+++ b/website/index.html
@@ -617,7 +617,7 @@
       <p>RCL is usable and useful, well-tested, and well-documented. It is still
       pre-1.0, though backwards-incompatible changes have been rare in the past
       years. Syntax highlighting is available for major editors like Vim, Emacs,
-      Helix, VSCode, and Zed. RCL is a community project without commercial support.
+      Helix, VSCode, JetBrains, and Zed. RCL is a community project without commercial support.
       </p>
     </div>
     <div class="span-full">


### PR DESCRIPTION
## Overview

This adds VSCode support (#80).

It took me some time to get started on this and wrap my head around the TextMate grammars. Today I picked it up again and it went pretty smoothly, I think it covers the full grammar now. There were some nuances around supporting incremental editing (e.g. `4.2e` should be a number even though it’s invalid syntax, because you don’t want the highlight to flicker off while typing `4.2e1`), and what scopes to use, but this is an initial version that I think is very usable.

The extension still needs a bit more polish, in particular it needs an icon and banner configuration, but it’s in a state where it can be tested. [I uploaded a preview version to the marketplace](https://marketplace.visualstudio.com/items?itemName=rcl-lang.rcl), feedback is welcome if anybody is reading along.

## Checklist

 * [x] Ensure documentation is up to date
 * [x] Ensure changelog is up to date
