### PR TITLE
feat: highlight RCL files on Github

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.rcl linguist-language=Rust


### PR DESCRIPTION
Highlight RCL files on Github (viewing files in the repo, in PRs) through a [linguist override](https://github.com/github-linguist/linguist/blob/main/docs/overrides.md). Linguist [has adoption quotas](https://github.com/github-linguist/linguist/blob/4ac734c15a96f9e16fd12330d0cb8de82274f700/CONTRIBUTING.md#adding-a-language) for adding languages, as mentioned in the README. In the meantime, it's possible to select a language close enough to enable meaningful syntax highlighting. This will slightly impact language usage statistics, but as RCL is not tracked yet this will just slightly overestimate the percentage of Rust in the project.

I believe no item below is applicable, this change only involves the Git repository itself. The change [works in my fork](https://github.com/matthieucx/rcl/blob/master/examples/tags.rcl).

 * [ ] Ensure documentation is up to date
 * [ ] Ensure changelog is up to date
 * [ ] Ensure test coverage
 * [ ] Ensure fuzzers discover new code paths
 * [ ] Ensure grammars and fuzz dictionary are up to date